### PR TITLE
Restore simulator and ESP Rust CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           path: |
             /root/.cargo
             /root/.rustup
-          key: rust-esp-toolchain-v3-espup016
+          key: rust-esp-toolchain-v4-rust185-espup016
           # Don't restore from older prefixes — older caches have espup 0.17.0
           # contents that break the build. Only match the fully-qualified key.
 
@@ -38,13 +38,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ ! -f "$HOME/.cargo/bin/cargo" ]; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+              sh -s -- -y --profile minimal --default-toolchain 1.85.0
           fi
           . "$HOME/.cargo/env"
+          rustup toolchain install 1.85.0 --profile minimal
           # Pin espup to 0.16.0 — 0.17.0 (released 2026-04-17) has a regression
           # that aborts with "Unsuported file extension: 'part'" during install.
           if ! command -v espup &> /dev/null || [ "$(espup --version 2>/dev/null | awk '{print $2}')" != "0.16.0" ]; then
-            cargo install espup --version 0.16.0 --force
+            cargo +1.85.0 install espup --version 0.16.0 --locked --force
           fi
           if ! command -v ldproxy &>/dev/null; then
             espup install
@@ -288,7 +290,7 @@ jobs:
             ~/.cargo
             ~/.rustup
             ~/.espup
-          key: rust-esp-recovery-${{ runner.os }}-v2-espup016
+          key: rust-esp-recovery-${{ runner.os }}-v3-rust185-espup016
           # Don't restore from older prefixes — v1 caches contain corrupt
           # espup 0.17.0 state that reproduces the "part" extension error.
 
@@ -296,13 +298,15 @@ jobs:
         shell: bash
         run: |
           if [ ! -f "$HOME/.cargo/bin/cargo" ]; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+              sh -s -- -y --profile minimal --default-toolchain 1.85.0
           fi
           . "$HOME/.cargo/env"
+          rustup toolchain install 1.85.0 --profile minimal
           # Pin espup to 0.16.0 — 0.17.0 (released 2026-04-17) has a regression
           # that aborts with "Unsuported file extension: 'part'" during install.
           if ! command -v espup &> /dev/null || [ "$(espup --version 2>/dev/null | awk '{print $2}')" != "0.16.0" ]; then
-            cargo install espup --version 0.16.0 --force
+            cargo +1.85.0 install espup --version 0.16.0 --locked --force
           fi
           # Clear any stale .part files from prior interrupted runs so espup
           # doesn't try to re-use them.
@@ -313,7 +317,7 @@ jobs:
           # ldproxy is the linker wrapper cargo invokes for xtensa-esp32s3-espidf.
           # espup installs the toolchain but not ldproxy; cargo install it explicitly.
           if ! command -v ldproxy &> /dev/null; then
-            cargo install ldproxy
+            cargo +1.85.0 install ldproxy --version 0.3.5 --locked
           fi
 
       - name: Cache recovery target dir

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -40,8 +40,6 @@ set(THISTLE_SRCS
     ${THISTLE_DIR}/components/apps_builtin/launcher/launcher_ui.c
     ${THISTLE_DIR}/components/apps_builtin/settings/settings_app.c
     ${THISTLE_DIR}/components/apps_builtin/settings/settings_ui.c
-    ${THISTLE_DIR}/components/apps_builtin/file_manager/filemgr_app.c
-    ${THISTLE_DIR}/components/apps_builtin/file_manager/filemgr_ui.c
     ${THISTLE_DIR}/components/apps_builtin/reader/reader_app.c
     ${THISTLE_DIR}/components/apps_builtin/reader/reader_ui.c
     ${THISTLE_DIR}/components/apps_builtin/messenger/messenger_app.c
@@ -66,6 +64,53 @@ set(THISTLE_SRCS
     ${THISTLE_DIR}/components/apps_builtin/vault/vault_app.c
     ${THISTLE_DIR}/components/apps_builtin/vault/vault_ui.c
 )
+
+# The simulator unit-test target is independent from optional built-in apps.
+# Keep CMake configuration valid when an app source is not present so CI can
+# still build and execute thistle_sim_tests.
+if(EXISTS "${THISTLE_DIR}/components/apps_builtin/file_manager/filemgr_app.c")
+    set(THISTLE_HAVE_FILEMGR 1)
+    list(APPEND THISTLE_SRCS
+        ${THISTLE_DIR}/components/apps_builtin/file_manager/filemgr_app.c
+        ${THISTLE_DIR}/components/apps_builtin/file_manager/filemgr_ui.c
+    )
+else()
+    set(THISTLE_HAVE_FILEMGR 0)
+endif()
+
+function(thistle_set_optional_app_flag flag source)
+    if(EXISTS "${THISTLE_DIR}/${source}")
+        set(${flag} 1 PARENT_SCOPE)
+    else()
+        set(${flag} 0 PARENT_SCOPE)
+    endif()
+endfunction()
+
+thistle_set_optional_app_flag(THISTLE_HAVE_READER
+    "components/apps_builtin/reader/reader_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_NAVIGATOR
+    "components/apps_builtin/navigator/navigator_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_NOTES
+    "components/apps_builtin/notes/notes_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_APPSTORE
+    "components/apps_builtin/appstore/appstore_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_WIFISCANNER
+    "components/apps_builtin/wifiscanner/wifiscanner_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_FLASHLIGHT
+    "components/apps_builtin/flashlight/flashlight_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_WEATHER
+    "components/apps_builtin/weather/weather_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_VAULT
+    "components/apps_builtin/vault/vault_app.c")
+
+set(THISTLE_SIM_SRCS)
+foreach(source IN LISTS THISTLE_SRCS)
+    if(EXISTS "${source}")
+        list(APPEND THISTLE_SIM_SRCS "${source}")
+    else()
+        message(STATUS "Skipping unavailable simulator app source: ${source}")
+    endif()
+endforeach()
 
 # Simulator sources
 set(SIM_SRCS
@@ -96,7 +141,7 @@ set(SIM_SRCS
     sim_assert.c
 )
 
-add_executable(thistle_sim ${SIM_SRCS} ${THISTLE_SRCS} ${LVGL_SRCS})
+add_executable(thistle_sim ${SIM_SRCS} ${THISTLE_SIM_SRCS} ${LVGL_SRCS})
 
 # Include paths — simulator platform stubs MUST come before any ThistleOS includes
 # so that #include "esp_log.h" finds our stub, not a real ESP-IDF header
@@ -129,6 +174,15 @@ target_compile_definitions(thistle_sim PRIVATE
     LV_COLOR_DEPTH=16
     # Disable ESP-IDF specific features
     SIMULATOR_BUILD=1
+    THISTLE_HAVE_FILEMGR=${THISTLE_HAVE_FILEMGR}
+    THISTLE_HAVE_READER=${THISTLE_HAVE_READER}
+    THISTLE_HAVE_NAVIGATOR=${THISTLE_HAVE_NAVIGATOR}
+    THISTLE_HAVE_NOTES=${THISTLE_HAVE_NOTES}
+    THISTLE_HAVE_APPSTORE=${THISTLE_HAVE_APPSTORE}
+    THISTLE_HAVE_WIFISCANNER=${THISTLE_HAVE_WIFISCANNER}
+    THISTLE_HAVE_FLASHLIGHT=${THISTLE_HAVE_FLASHLIGHT}
+    THISTLE_HAVE_WEATHER=${THISTLE_HAVE_WEATHER}
+    THISTLE_HAVE_VAULT=${THISTLE_HAVE_VAULT}
     CONFIG_LOG_DEFAULT_LEVEL=3
     # SD card path for simulator — points to local sdcard directory
     THISTLE_SDCARD_PATH="/tmp/thistle_sdcard"

--- a/simulator/main.c
+++ b/simulator/main.c
@@ -31,18 +31,36 @@ void sim_lvgl_unlock(void) { pthread_mutex_unlock(&s_lvgl_mutex); }
 #include "sim_scenario.h"
 #include "launcher/launcher_app.h"
 #include "settings/settings_app.h"
+#if THISTLE_HAVE_FILEMGR
 #include "file_manager/filemgr_app.h"
+#endif
+#if THISTLE_HAVE_READER
 #include "reader/reader_app.h"
+#endif
 #include "messenger/messenger_app.h"
+#if THISTLE_HAVE_NAVIGATOR
 #include "navigator/navigator_app.h"
+#endif
+#if THISTLE_HAVE_NOTES
 #include "notes/notes_app.h"
+#endif
+#if THISTLE_HAVE_APPSTORE
 #include "appstore/appstore_app.h"
+#endif
 #include "assistant/assistant_app.h"
+#if THISTLE_HAVE_WIFISCANNER
 #include "wifiscanner/wifiscanner_app.h"
+#endif
+#if THISTLE_HAVE_FLASHLIGHT
 #include "flashlight/flashlight_app.h"
+#endif
+#if THISTLE_HAVE_WEATHER
 #include "weather/weather_app.h"
+#endif
 #include "terminal/terminal_app.h"
+#if THISTLE_HAVE_VAULT
 #include "vault/vault_app.h"
+#endif
 
 static bool s_headless = false;
 static int  s_timeout_ms = 0;
@@ -127,26 +145,44 @@ int main(int argc, char **argv)
     /* Register built-in apps (always available) */
     launcher_app_register();
     settings_app_register();
+#if THISTLE_HAVE_FILEMGR
     filemgr_app_register();
+#endif
+#if THISTLE_HAVE_READER
     reader_app_register();
+#endif
+#if THISTLE_HAVE_NOTES
     notes_app_register();
+#endif
+#if THISTLE_HAVE_FLASHLIGHT
     flashlight_app_register();
+#endif
+#if THISTLE_HAVE_VAULT
     vault_app_register();
+#endif
+#if THISTLE_HAVE_APPSTORE
     appstore_app_register();
+#endif
     terminal_app_register();
     assistant_app_register();
+#if THISTLE_HAVE_WEATHER
     weather_app_register();
+#endif
 
     /* Conditional apps based on device capabilities */
     extern bool sim_board_has_radio(void);
     extern bool sim_board_has_gps(void);
     if (sim_board_has_radio()) {
         messenger_app_register();
+#if THISTLE_HAVE_WIFISCANNER
         wifiscanner_app_register();
+#endif
     }
+#if THISTLE_HAVE_NAVIGATOR
     if (sim_board_has_gps()) {
         navigator_app_register();
     }
+#endif
     app_manager_launch("com.thistle.launcher");
     printf("Launcher launched\n");
     sim_assert_check_line("Launcher launched");


### PR DESCRIPTION
## What changed

- makes simulator built-in apps conditional on whether their source exists
- guards the matching app headers and registration calls
- pins the host Rust bootstrap used to install `espup` to Rust 1.85.0
- installs `espup 0.16.0` and `ldproxy 0.3.5` with locked dependency resolution
- rotates the Rust/ESP cache keys so stale nightly-built tools are not restored

## Why

The shared simulator job referenced built-in app sources that are no longer present, so dependency PRs failed before exercising their own changes. Separately, the firmware workflow compiled `espup` with an unbounded nightly toolchain; the 2026-07-24 nightly hit a compiler ICE while building a transitive Tokio dependency.

This repair removes both shared failure modes and is intended to unblock reassessment of PRs #31, #32, #33, #34, and #63.

## Validation

Validated from a clean archive of `HEAD` with only this commit's staged patch applied and the same LVGL v9.2.2 dependency supplied by CI:

- workflow YAML parsing: pass
- simulator unit tests: 16/16 pass
- full simulator build: pass
- headless T-Deck launcher boot: pass
- boot assertions: 10/10 pass
- architecture-coverage tool tests: 6/6 pass
- `git diff --check`: pass

Firmware/recovery compilation remains delegated to GitHub Actions because the required ESP-IDF/Rust target environment is not available locally.