### PR TITLE
Fix manifest loader buffer overflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,3 +180,42 @@ jobs:
       - name: Run kernel tests
         working-directory: components/kernel_rs
         run: cargo test --target x86_64-unknown-linux-gnu -- --test-threads=1
+
+  manifest-memory-safety:
+    name: Manifest Loader (Valgrind)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install Rust and Valgrind
+        run: |
+          if [ ! -f "$HOME/.cargo/bin/cargo" ]; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          fi
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          sudo apt-get update
+          sudo apt-get install -y valgrind
+
+      - name: Build manifest parser test binary
+        working-directory: components/kernel_rs
+        run: |
+          cargo test --target x86_64-unknown-linux-gnu --locked --no-run \
+            --message-format=json > /tmp/thistle-test-artifacts.json
+          jq -r \
+            'select(.profile.test == true and .executable != null and .target.name == "thistle_kernel") | .executable' \
+            /tmp/thistle-test-artifacts.json | tail -n 1 > /tmp/thistle-test-binary
+          test -s /tmp/thistle-test-binary
+          test -x "$(cat /tmp/thistle-test-binary)"
+
+      - name: Check maximal manifest parse under Valgrind
+        run: |
+          valgrind \
+            --tool=memcheck \
+            --error-exitcode=1 \
+            --leak-check=no \
+            --track-origins=yes \
+            "$(cat /tmp/thistle-test-binary)" \
+            ffi::tests::maximal_manifest_parse_stays_within_typed_loader_storage \
+            --exact --test-threads=1

--- a/components/kernel/include/thistle/manifest.h
+++ b/components/kernel/include/thistle/manifest.h
@@ -4,8 +4,9 @@
 #pragma once
 
 #include "esp_err.h"
-#include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 /* Manifest types — apps, drivers, and firmware share the same schema */
 typedef enum {
@@ -52,6 +53,37 @@ typedef struct {
     /* Firmware-specific */
     char changelog[256];       /* What changed in this version */
 } thistle_manifest_t;
+
+/* Keep the public C layout synchronized with Rust's #[repr(C)] CManifest. */
+#if defined(__cplusplus)
+#define THISTLE_MANIFEST_STATIC_ASSERT(condition, message) static_assert(condition, message)
+#define THISTLE_MANIFEST_ALIGNOF(type) alignof(type)
+#else
+#define THISTLE_MANIFEST_STATIC_ASSERT(condition, message) _Static_assert(condition, message)
+#define THISTLE_MANIFEST_ALIGNOF(type) _Alignof(type)
+#endif
+
+THISTLE_MANIFEST_STATIC_ASSERT(sizeof(manifest_type_t) == 4,
+                               "manifest_type_t ABI must remain 4 bytes");
+THISTLE_MANIFEST_STATIC_ASSERT(sizeof(thistle_manifest_t) == 720,
+                               "thistle_manifest_t ABI size mismatch");
+THISTLE_MANIFEST_STATIC_ASSERT(THISTLE_MANIFEST_ALIGNOF(thistle_manifest_t) == 4,
+                               "thistle_manifest_t ABI alignment mismatch");
+THISTLE_MANIFEST_STATIC_ASSERT(offsetof(thistle_manifest_t, id) == 4,
+                               "thistle_manifest_t.id ABI offset mismatch");
+THISTLE_MANIFEST_STATIC_ASSERT(offsetof(thistle_manifest_t, permissions) == 436,
+                               "thistle_manifest_t.permissions ABI offset mismatch");
+THISTLE_MANIFEST_STATIC_ASSERT(offsetof(thistle_manifest_t, background) == 440,
+                               "thistle_manifest_t.background ABI offset mismatch");
+THISTLE_MANIFEST_STATIC_ASSERT(offsetof(thistle_manifest_t, min_memory_kb) == 444,
+                               "thistle_manifest_t.min_memory_kb ABI offset mismatch");
+THISTLE_MANIFEST_STATIC_ASSERT(offsetof(thistle_manifest_t, hal_interface) == 448,
+                               "thistle_manifest_t.hal_interface ABI offset mismatch");
+THISTLE_MANIFEST_STATIC_ASSERT(offsetof(thistle_manifest_t, changelog) == 464,
+                               "thistle_manifest_t.changelog ABI offset mismatch");
+
+#undef THISTLE_MANIFEST_STATIC_ASSERT
+#undef THISTLE_MANIFEST_ALIGNOF
 
 /* Parse a manifest.json file from the given path.
  * Returns ESP_OK on success, ESP_ERR_NOT_FOUND if file missing,

--- a/components/kernel_rs/src/driver_loader.rs
+++ b/components/kernel_rs/src/driver_loader.rs
@@ -9,6 +9,8 @@ use std::ffi::CStr;
 use std::os::raw::{c_char, c_int, c_void};
 use std::sync::Mutex;
 
+use crate::ffi::CManifest;
+
 // ---------------------------------------------------------------------------
 // ESP-IDF error codes
 // ---------------------------------------------------------------------------
@@ -45,8 +47,8 @@ extern "C" {
     fn signing_verify_file(path: *const c_char) -> i32;
 
     // Manifest (C/Rust shims)
-    fn manifest_parse_file(path: *const c_char, out: *mut c_void) -> i32;
-    fn manifest_is_compatible(manifest: *const c_void, current_arch: *const c_char) -> bool;
+    fn manifest_parse_file(path: *const c_char, out: *mut CManifest) -> i32;
+    fn manifest_is_compatible(manifest: *const CManifest, current_arch: *const c_char) -> bool;
     fn manifest_path_from_elf(elf_path: *const c_char, out: *mut c_char, out_size: usize);
 
     // Syscall table (C)
@@ -400,23 +402,22 @@ pub unsafe extern "C" fn driver_loader_load(path: *const c_char) -> i32 {
             manifest_path_buf.len(),
         );
 
-        // Use a heap-allocated opaque blob for the manifest struct
-        let manifest_buf = heap_caps_malloc(512, MALLOC_CAP_SPIRAM);
-        if !manifest_buf.is_null() {
-            if manifest_parse_file(manifest_path_buf.as_ptr() as *const c_char, manifest_buf) == ESP_OK {
-                if !manifest_is_compatible(manifest_buf as *const c_void, CURRENT_ARCH.as_ptr() as *const c_char) {
-                    esp_log_write(
-                        ESP_LOG_ERROR,
-                        TAG.as_ptr(),
-                        b"Driver incompatible: %s\0".as_ptr(),
-                        path,
-                    );
-                    free(manifest_buf);
-                    return ESP_ERR_NOT_SUPPORTED;
-                }
-                esp_log_write(ESP_LOG_INFO, TAG.as_ptr(), b"Driver manifest OK: %s\0".as_ptr(), path);
+        let mut manifest = std::mem::MaybeUninit::<CManifest>::uninit();
+        if manifest_parse_file(
+            manifest_path_buf.as_ptr() as *const c_char,
+            manifest.as_mut_ptr(),
+        ) == ESP_OK {
+            let manifest = manifest.assume_init();
+            if !manifest_is_compatible(&manifest, CURRENT_ARCH.as_ptr() as *const c_char) {
+                esp_log_write(
+                    ESP_LOG_ERROR,
+                    TAG.as_ptr(),
+                    b"Driver incompatible: %s\0".as_ptr(),
+                    path,
+                );
+                return ESP_ERR_NOT_SUPPORTED;
             }
-            free(manifest_buf);
+            esp_log_write(ESP_LOG_INFO, TAG.as_ptr(), b"Driver manifest OK: %s\0".as_ptr(), path);
         }
     }
 

--- a/components/kernel_rs/src/elf_loader.rs
+++ b/components/kernel_rs/src/elf_loader.rs
@@ -76,8 +76,8 @@ extern "C" {
     fn permissions_grant(app_id: *const c_char, perms: u32) -> i32;
 
     // Manifest (C/Rust)
-    fn manifest_parse_file(path: *const c_char, out: *mut c_void) -> i32;
-    fn manifest_is_compatible(manifest: *const c_void, current_arch: *const c_char) -> bool;
+    fn manifest_parse_file(path: *const c_char, out: *mut CManifest) -> i32;
+    fn manifest_is_compatible(manifest: *const CManifest, current_arch: *const c_char) -> bool;
     fn manifest_path_from_elf(elf_path: *const c_char, out: *mut c_char, out_size: usize);
 
     // Syscall table
@@ -344,20 +344,17 @@ pub unsafe extern "C" fn elf_app_load(
     {
         let mut manifest_path_buf = [0u8; 280];
         manifest_path_from_elf(path, manifest_path_buf.as_mut_ptr() as *mut c_char, manifest_path_buf.len());
-        let manifest_buf = heap_caps_malloc(512, MALLOC_CAP_SPIRAM);
-        if !manifest_buf.is_null() {
-            if manifest_parse_file(manifest_path_buf.as_ptr() as *const c_char, manifest_buf) == ESP_OK {
-                // Extract the "id" field from the parsed manifest
-                let id_ptr = (manifest_buf as *const u8).add(1); // type is first byte, id starts at offset 1
-                // The CManifest struct has id at offset 1 (after u8 type), as [u8; 64]
-                let id_bytes = std::slice::from_raw_parts(id_ptr, 64);
-                let id_len = id_bytes.iter().position(|&b| b == 0).unwrap_or(64);
-                if id_len > 0 {
-                    app_id_buf[..id_len].copy_from_slice(&id_bytes[..id_len]);
-                    has_manifest_id = true;
-                }
+        let mut manifest = std::mem::MaybeUninit::<CManifest>::uninit();
+        if manifest_parse_file(
+            manifest_path_buf.as_ptr() as *const c_char,
+            manifest.as_mut_ptr(),
+        ) == ESP_OK {
+            let manifest = manifest.assume_init();
+            let id_len = manifest.id.iter().position(|&b| b == 0).unwrap_or(64);
+            if id_len > 0 {
+                app_id_buf[..id_len].copy_from_slice(&manifest.id[..id_len]);
+                has_manifest_id = true;
             }
-            free(manifest_buf);
         }
     }
 
@@ -447,18 +444,18 @@ pub unsafe extern "C" fn elf_app_load(
         let mut manifest_path_buf = [0u8; 280];
         manifest_path_from_elf(path, manifest_path_buf.as_mut_ptr() as *mut c_char, manifest_path_buf.len());
 
-        let manifest_buf = heap_caps_malloc(512, MALLOC_CAP_SPIRAM);
-        if !manifest_buf.is_null() {
-            if manifest_parse_file(manifest_path_buf.as_ptr() as *const c_char, manifest_buf) == ESP_OK {
-                if !manifest_is_compatible(manifest_buf as *const c_void, CURRENT_ARCH.as_ptr() as *const c_char) {
-                    esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"App incompatible: %s\0".as_ptr(), path);
-                    esp_elf_deinit(elf_ptr);
-                    free(manifest_buf);
-                    return ESP_ERR_NOT_SUPPORTED;
-                }
-                esp_log_write(ESP_LOG_INFO, TAG.as_ptr(), b"Manifest OK: %s\0".as_ptr(), path);
+        let mut manifest = std::mem::MaybeUninit::<CManifest>::uninit();
+        if manifest_parse_file(
+            manifest_path_buf.as_ptr() as *const c_char,
+            manifest.as_mut_ptr(),
+        ) == ESP_OK {
+            let manifest = manifest.assume_init();
+            if !manifest_is_compatible(&manifest, CURRENT_ARCH.as_ptr() as *const c_char) {
+                esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"App incompatible: %s\0".as_ptr(), path);
+                esp_elf_deinit(elf_ptr);
+                return ESP_ERR_NOT_SUPPORTED;
             }
-            free(manifest_buf);
+            esp_log_write(ESP_LOG_INFO, TAG.as_ptr(), b"Manifest OK: %s\0".as_ptr(), path);
         }
     }
 
@@ -833,7 +830,7 @@ pub unsafe extern "C" fn elf_app_scan_and_register() -> c_int {
             let mut c_manifest = std::mem::zeroed::<CManifest>();
             let manifest_ret = manifest_parse_file(
                 manifest_path_buf.as_ptr() as *const c_char,
-                &mut c_manifest as *mut CManifest as *mut c_void,
+                &mut c_manifest,
             );
 
             if manifest_ret != ESP_OK {

--- a/components/kernel_rs/src/ffi.rs
+++ b/components/kernel_rs/src/ffi.rs
@@ -15,7 +15,9 @@ use crate::manifest::Manifest;
 /// Field sizes must match the C header (manifest.h).
 #[repr(C)]
 pub struct CManifest {
-    pub manifest_type: u8, // ManifestType enum value
+    // `manifest_type_t` is a normal C enum and occupies four bytes in the
+    // public ABI. Narrowing this field shifts the following string fields.
+    pub manifest_type: u32,
     pub id: [u8; 64],
     pub name: [u8; 32],
     pub version: [u8; 16],
@@ -47,7 +49,7 @@ fn copy_to_buf(src: &str, dst: &mut [u8]) {
 impl From<&Manifest> for CManifest {
     fn from(m: &Manifest) -> Self {
         let mut c = CManifest {
-            manifest_type: m.manifest_type as u8,
+            manifest_type: m.manifest_type as u32,
             id: [0; 64],
             name: [0; 32],
             version: [0; 16],
@@ -91,10 +93,7 @@ const ESP_ERR_NOT_SUPPORTED: i32 = 0x106;
 /// `json_path` must be a valid null-terminated C string.
 /// `out` must point to a valid CManifest-sized buffer.
 #[no_mangle]
-pub unsafe extern "C" fn manifest_parse_file(
-    json_path: *const c_char,
-    out: *mut CManifest,
-) -> i32 {
+pub unsafe extern "C" fn manifest_parse_file(json_path: *const c_char, out: *mut CManifest) -> i32 {
     if json_path.is_null() || out.is_null() {
         return ESP_ERR_INVALID_ARG;
     }
@@ -190,4 +189,106 @@ pub unsafe extern "C" fn manifest_path_from_elf(
 pub extern "C" fn kernel_version() -> *const c_char {
     // Include the null terminator
     b"0.1.0\0".as_ptr() as *const c_char
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{manifest_parse_file, CManifest, ESP_OK};
+    use std::ffi::{CStr, CString};
+    use std::mem::{align_of, offset_of, size_of, MaybeUninit};
+
+    #[test]
+    fn c_manifest_layout_matches_public_c_abi() {
+        assert_eq!(size_of::<CManifest>(), 720);
+        assert_eq!(align_of::<CManifest>(), 4);
+        assert_eq!(offset_of!(CManifest, manifest_type), 0);
+        assert_eq!(offset_of!(CManifest, id), 4);
+        assert_eq!(offset_of!(CManifest, permissions), 436);
+        assert_eq!(offset_of!(CManifest, background), 440);
+        assert_eq!(offset_of!(CManifest, min_memory_kb), 444);
+        assert_eq!(offset_of!(CManifest, hal_interface), 448);
+        assert_eq!(offset_of!(CManifest, changelog), 464);
+    }
+
+    #[test]
+    fn manifest_loaders_do_not_use_the_legacy_opaque_buffer() {
+        const LEGACY_BUFFER: &str = concat!("heap_caps_malloc(", "512, MALLOC_CAP_SPIRAM)");
+
+        assert!(!include_str!("elf_loader.rs").contains(LEGACY_BUFFER));
+        assert!(!include_str!("driver_loader.rs").contains(LEGACY_BUFFER));
+    }
+
+    #[test]
+    fn maximal_manifest_parse_stays_within_typed_loader_storage() {
+        #[repr(C)]
+        struct GuardedManifest {
+            before: [u8; 32],
+            manifest: MaybeUninit<CManifest>,
+            after: [u8; 32],
+        }
+
+        let json = format!(
+            r#"{{
+                "type":"firmware",
+                "id":"{}",
+                "name":"{}",
+                "version":"{}",
+                "author":"{}",
+                "description":"{}",
+                "min_os":"{}",
+                "arch":"{}",
+                "entry":"{}",
+                "icon":"{}",
+                "permissions":["storage","network","radio","gps","audio","system","ipc"],
+                "background":true,
+                "min_memory_kb":4294967295,
+                "hal_interface":"{}",
+                "changelog":"{}"
+            }}"#,
+            "i".repeat(63),
+            "n".repeat(31),
+            "1".repeat(15),
+            "a".repeat(31),
+            "d".repeat(127),
+            "0".repeat(15),
+            "r".repeat(15),
+            "e".repeat(63),
+            "o".repeat(63),
+            "h".repeat(15),
+            "c".repeat(255),
+        );
+
+        let path = std::env::temp_dir().join(format!(
+            "thistle-maximal-manifest-{}.json",
+            std::process::id()
+        ));
+        std::fs::write(&path, json).expect("write maximal manifest fixture");
+        let c_path = CString::new(path.to_string_lossy().as_bytes()).unwrap();
+
+        let mut guarded = GuardedManifest {
+            before: [0xA5; 32],
+            manifest: MaybeUninit::uninit(),
+            after: [0x5A; 32],
+        };
+        let result = unsafe { manifest_parse_file(c_path.as_ptr(), guarded.manifest.as_mut_ptr()) };
+        let _ = std::fs::remove_file(path);
+
+        assert_eq!(result, ESP_OK);
+        assert_eq!(guarded.before, [0xA5; 32]);
+        assert_eq!(guarded.after, [0x5A; 32]);
+
+        let manifest = unsafe { guarded.manifest.assume_init() };
+        assert_eq!(
+            unsafe { CStr::from_ptr(manifest.id.as_ptr().cast()) }
+                .to_bytes()
+                .len(),
+            63
+        );
+        assert_eq!(
+            unsafe { CStr::from_ptr(manifest.changelog.as_ptr().cast()) }
+                .to_bytes()
+                .len(),
+            255
+        );
+    }
 }


### PR DESCRIPTION
## What changed

- replaces all three 512-byte opaque manifest allocations with typed `MaybeUninit<CManifest>` storage
- makes loader FFI declarations use typed manifest pointers
- reads the manifest ID through the typed field instead of an incorrect byte offset
- corrects Rust's manifest enum field to the four-byte C ABI representation
- adds matching C/C++ compile-time size, alignment, and field-offset assertions
- adds a maximal-manifest regression with guard regions around the real parser output

## Root cause

`manifest_parse_file()` writes a 720-byte manifest, while the app and driver loaders allocated only 512 bytes. The Rust representation also used a one-byte manifest type even though the public C enum is four bytes, shifting the identity fields across the ABI boundary.

## Validation

- focused manifest FFI tests: 3 passed
- full Rust kernel suite: 1,281 passed
- C11 manifest header compilation: passed
- C++17 manifest header compilation: passed
- legacy 512-byte loader allocation scan: passed
- `git diff --check`: passed

Native Rust ASan remains unverified because the macOS sanitizer runtime deadlocks during dyld initialization on the available host. The guarded maximal-manifest regression is deterministic, but issue #35 should remain open until the remaining instrumentation requirement is satisfied.

Addresses #35.