### PR TITLE
Fail closed on signature verification errors

### DIFF
--- a/components/kernel_rs/src/driver_loader.rs
+++ b/components/kernel_rs/src/driver_loader.rs
@@ -258,6 +258,23 @@ unsafe impl Send for DriverLoaderState {}
 static EMPTY_CONFIG: &[u8] = b"{}\0";
 static STATE: Mutex<DriverLoaderState> = Mutex::new(DriverLoaderState::new());
 
+/// Return whether signature policy permits loading a driver. Production
+/// accepts only a verified signature. Debug builds retain the deliberate
+/// development exception for an absent `.sig`, but malformed signatures and
+/// all verifier failures remain fatal.
+fn driver_signature_allows_load(signature_result: i32) -> Result<bool, i32> {
+    if signature_result == ESP_OK {
+        return Ok(true);
+    }
+
+    if signature_result == ESP_ERR_NOT_FOUND {
+        #[cfg(debug_assertions)]
+        return Ok(false);
+    }
+
+    Err(signature_result)
+}
+
 // ---------------------------------------------------------------------------
 // Symbol resolver — delegates to the kernel syscall table
 // ---------------------------------------------------------------------------
@@ -372,25 +389,33 @@ pub unsafe extern "C" fn driver_loader_load(path: *const c_char) -> i32 {
     }
 
     // 1. Verify signature
-    let sig_ret = signing_verify_file(path);
-    if sig_ret == ESP_ERR_INVALID_CRC {
-        esp_log_write(
-            ESP_LOG_ERROR,
-            TAG.as_ptr(),
-            b"Driver signature INVALID: %s\0".as_ptr(),
-            path,
-        );
-        return ESP_ERR_INVALID_CRC;
-    } else if sig_ret == ESP_ERR_NOT_FOUND {
-        #[cfg(not(debug_assertions))]
-        {
-            esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"Driver unsigned: %s (REFUSED - production)\0".as_ptr(), path);
-            return ESP_ERR_INVALID_CRC;
+    match driver_signature_allows_load(signing_verify_file(path)) {
+        Ok(true) => {
+            esp_log_write(
+                ESP_LOG_INFO,
+                TAG.as_ptr(),
+                b"Driver signature verified: %s\0".as_ptr(),
+                path,
+            );
         }
-        #[cfg(debug_assertions)]
-        esp_log_write(ESP_LOG_WARN, TAG.as_ptr(), b"Driver unsigned (dev mode): %s\0".as_ptr(), path);
-    } else if sig_ret == ESP_OK {
-        esp_log_write(ESP_LOG_INFO, TAG.as_ptr(), b"Driver signature verified: %s\0".as_ptr(), path);
+        Ok(false) => {
+            esp_log_write(
+                ESP_LOG_WARN,
+                TAG.as_ptr(),
+                b"Driver unsigned (dev mode): %s\0".as_ptr(),
+                path,
+            );
+        }
+        Err(err) => {
+            esp_log_write(
+                ESP_LOG_ERROR,
+                TAG.as_ptr(),
+                b"Driver signature verification failed: %d for %s\0".as_ptr(),
+                err,
+                path,
+            );
+            return err;
+        }
     }
 
     // 2. Parse manifest (optional)
@@ -702,5 +727,27 @@ mod tests {
     #[test]
     fn test_max_loaded_drvs_constant() {
         assert_eq!(MAX_LOADED_DRVS, 8, "MAX_LOADED_DRVS must be 8");
+    }
+
+    #[test]
+    fn test_driver_signature_gate_rejects_verifier_errors() {
+        assert_eq!(driver_signature_allows_load(ESP_OK), Ok(true));
+
+        #[cfg(debug_assertions)]
+        assert_eq!(driver_signature_allows_load(ESP_ERR_NOT_FOUND), Ok(false));
+        #[cfg(not(debug_assertions))]
+        assert_eq!(
+            driver_signature_allows_load(ESP_ERR_NOT_FOUND),
+            Err(ESP_ERR_NOT_FOUND)
+        );
+
+        for error in [
+            ESP_ERR_INVALID_CRC,
+            ESP_ERR_INVALID_SIZE,
+            0x103, // ESP_ERR_INVALID_STATE
+            ESP_ERR_INVALID_ARG,
+        ] {
+            assert_eq!(driver_signature_allows_load(error), Err(error));
+        }
     }
 }

--- a/components/kernel_rs/src/ota.rs
+++ b/components/kernel_rs/src/ota.rs
@@ -67,6 +67,17 @@ extern "C" {
 // Progress callback type — matches C typedef `void (*ota_progress_cb_t)(uint32_t written, uint32_t total, void *user_data)`
 pub type OtaProgressCb = unsafe extern "C" fn(written: u32, total: u32, user_data: *mut c_void);
 
+/// OTA images are production artifacts, so only an explicit verifier success
+/// may cross the firmware trust boundary. Preserve the verifier's exact error
+/// for diagnostics instead of treating non-CRC failures as success.
+fn require_valid_ota_signature(signature_result: i32) -> Result<(), i32> {
+    if signature_result == ESP_OK {
+        Ok(())
+    } else {
+        Err(signature_result)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // FFI exports
 // ---------------------------------------------------------------------------
@@ -144,13 +155,14 @@ pub unsafe extern "C" fn ota_apply_from_sd(
 
     // 1. Verify signature
     let sig_ret = signing_verify_file(update_path_cstr);
-    if sig_ret == ESP_ERR_INVALID_CRC {
+    if let Err(err) = require_valid_ota_signature(sig_ret) {
         esp_log_write(
             ESP_LOG_ERROR,
             TAG.as_ptr(),
-            b"OTA update signature INVALID\0".as_ptr(),
+            b"OTA update signature verification failed: %d\0".as_ptr(),
+            err,
         );
-        return ESP_ERR_INVALID_CRC;
+        return err;
     }
 
     // 2. Open and size-check the update file
@@ -369,6 +381,22 @@ pub extern "C" fn ota_rollback() -> i32 {
 mod tests {
     use super::*;
     use std::ffi::CStr;
+
+    #[test]
+    fn test_ota_signature_gate_fails_closed_for_all_verifier_errors() {
+        assert_eq!(require_valid_ota_signature(ESP_OK), Ok(()));
+
+        for error in [
+            ESP_ERR_NOT_FOUND,
+            ESP_ERR_INVALID_CRC,
+            ESP_ERR_INVALID_SIZE,
+            0x103, // ESP_ERR_INVALID_STATE
+            0x102, // ESP_ERR_INVALID_ARG
+            ESP_ERR_NO_MEM,
+        ] {
+            assert_eq!(require_valid_ota_signature(error), Err(error));
+        }
+    }
 
     // -----------------------------------------------------------------------
     // test_get_current_version_non_null

--- a/components/kernel_rs/src/signing.rs
+++ b/components/kernel_rs/src/signing.rs
@@ -211,7 +211,8 @@ pub extern "C" fn signing_get_public_key_hex() -> *const c_char {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ed25519_dalek::SigningKey;
+    use ed25519_dalek::{Signer, SigningKey};
+    use std::ffi::CString;
 
     /// Reset global state between tests so they are independent.
     fn reset() {
@@ -227,6 +228,19 @@ mod tests {
         let seed = [0x42u8; 32];
         let signing_key = SigningKey::from_bytes(&seed);
         signing_key.verifying_key().to_bytes()
+    }
+
+    fn temp_payload_path(case: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "thistle-signing-{case}-{}-{}.elf",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ))
+    }
+
+    fn remove_payload_fixture(path: &std::path::Path) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(sig_path_for(path.to_string_lossy().as_ref()));
     }
 
     #[test]
@@ -402,6 +416,71 @@ mod tests {
             result, ESP_ERR_NOT_FOUND,
             "signing_verify_file on missing path must return ESP_ERR_NOT_FOUND"
         );
+    }
+
+    #[test]
+    fn test_verify_file_rejects_63_and_65_byte_signatures() {
+        reset();
+        let payload_path = temp_payload_path("bad-length");
+        remove_payload_fixture(&payload_path);
+        let signature_path = sig_path_for(payload_path.to_string_lossy().as_ref());
+        std::fs::write(&payload_path, b"signed payload").unwrap();
+        let c_path = CString::new(payload_path.to_string_lossy().as_bytes()).unwrap();
+
+        for length in [63, 65] {
+            std::fs::write(&signature_path, vec![0u8; length]).unwrap();
+            assert_eq!(
+                unsafe { signing_verify_file(c_path.as_ptr()) },
+                ESP_ERR_INVALID_SIZE,
+                "{length}-byte signature must fail closed"
+            );
+        }
+
+        remove_payload_fixture(&payload_path);
+    }
+
+    #[test]
+    fn test_verify_file_rejects_unreadable_payload() {
+        reset();
+        let payload_path = temp_payload_path("unreadable");
+        remove_payload_fixture(&payload_path);
+        std::fs::create_dir(&payload_path).unwrap();
+        let signature_path = sig_path_for(payload_path.to_string_lossy().as_ref());
+        std::fs::write(&signature_path, [0u8; 64]).unwrap();
+        let c_path = CString::new(payload_path.to_string_lossy().as_bytes()).unwrap();
+
+        assert_eq!(
+            unsafe { signing_verify_file(c_path.as_ptr()) },
+            ESP_ERR_NOT_FOUND
+        );
+
+        let _ = std::fs::remove_file(signature_path);
+        let _ = std::fs::remove_dir(payload_path);
+    }
+
+    #[test]
+    fn test_verify_file_accepts_valid_and_rejects_tampered_payload() {
+        reset();
+        let payload_path = temp_payload_path("valid-and-tampered");
+        remove_payload_fixture(&payload_path);
+        let signature_path = sig_path_for(payload_path.to_string_lossy().as_ref());
+        let payload = b"production driver or firmware payload";
+        let signing_key = SigningKey::from_bytes(&[0x77; 32]);
+        let verifying_key = signing_key.verifying_key().to_bytes();
+        assert_eq!(unsafe { signing_init(verifying_key.as_ptr()) }, ESP_OK);
+
+        std::fs::write(&payload_path, payload).unwrap();
+        std::fs::write(&signature_path, signing_key.sign(payload).to_bytes()).unwrap();
+        let c_path = CString::new(payload_path.to_string_lossy().as_bytes()).unwrap();
+        assert_eq!(unsafe { signing_verify_file(c_path.as_ptr()) }, ESP_OK);
+
+        std::fs::write(&payload_path, b"tampered payload").unwrap();
+        assert_eq!(
+            unsafe { signing_verify_file(c_path.as_ptr()) },
+            ESP_ERR_INVALID_CRC
+        );
+
+        remove_payload_fixture(&payload_path);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- require an explicit `ESP_OK` before OTA file access or any flash operation
- fail closed on every production driver verifier error while preserving the debug-only missing-signature development exception
- preserve exact verifier error codes for diagnostics
- add real file fixtures for malformed, unreadable, valid, and tampered signatures

## Validation

- `cargo test --target aarch64-apple-darwin --locked -- --test-threads=1` — 1,286 passed
- focused driver policy test also passed under `--release`, proving production rejects a missing signature
- `git diff --check`

## Stack

This draft is intentionally based on `codex/fix-manifest-buffer` / PR #79 because both changes touch `driver_loader.rs`. Review only commit `0e14c6b` for this issue.

Addresses #36. The issue should remain open until ESP-IDF CI and the stacked integration are green.