### PR TITLE
Restrict app syscalls and correct driver bus ABI

### DIFF
--- a/components/kernel_rs/src/elf_loader.rs
+++ b/components/kernel_rs/src/elf_loader.rs
@@ -74,6 +74,7 @@ extern "C" {
 
     // Permissions (Rust)
     fn permissions_grant(app_id: *const c_char, perms: u32) -> i32;
+    fn permissions_revoke(app_id: *const c_char, perms: u32) -> i32;
 
     // Manifest (C/Rust)
     fn manifest_parse_file(path: *const c_char, out: *mut CManifest) -> i32;
@@ -81,7 +82,6 @@ extern "C" {
     fn manifest_path_from_elf(elf_path: *const c_char, out: *mut c_char, out_size: usize);
 
     // Syscall table
-    fn syscall_resolve(name: *const c_char) -> *mut c_void;
     fn syscall_table_count() -> usize;
     fn syscall_set_current_app(id: *const c_char);
 
@@ -115,6 +115,8 @@ pub struct ElfAppHandle {
     running: bool,
     load_addr: usize,
     load_size: usize,
+    app_id: [u8; 64],
+    granted_permissions: u32,
     // Slot index in the global array
     slot: usize,
 }
@@ -132,6 +134,8 @@ impl ElfAppHandle {
             running: false,
             load_addr: 0,
             load_size: 0,
+            app_id: [0u8; 64],
+            granted_permissions: 0,
             slot: 0,
         }
     }
@@ -174,12 +178,16 @@ unsafe impl Send for ElfLoaderState {}
 
 static STATE: Mutex<ElfLoaderState> = Mutex::new(ElfLoaderState::new());
 
+fn effective_app_permissions(signed: bool, requested: u32) -> u32 {
+    if signed { requested } else { PERM_IPC }
+}
+
 // ---------------------------------------------------------------------------
 // Symbol resolver
 // ---------------------------------------------------------------------------
 
-unsafe extern "C" fn thistle_symbol_resolver(sym_name: *const c_char) -> usize {
-    let addr = syscall_resolve(sym_name);
+unsafe extern "C" fn signed_app_symbol_resolver(sym_name: *const c_char) -> usize {
+    let addr = crate::syscall_table::syscall_resolve_signed_app(sym_name);
     if addr.is_null() {
         esp_log_write(
             ESP_LOG_WARN,
@@ -191,6 +199,10 @@ unsafe extern "C" fn thistle_symbol_resolver(sym_name: *const c_char) -> usize {
     } else {
         addr as usize
     }
+}
+
+unsafe extern "C" fn unsigned_app_symbol_resolver(sym_name: *const c_char) -> usize {
+    crate::syscall_table::syscall_resolve_unsigned_app(sym_name) as usize
 }
 
 // ---------------------------------------------------------------------------
@@ -341,6 +353,7 @@ pub unsafe extern "C" fn elf_app_load(
     // 3. Parse manifest FIRST to get the app ID for permission identity
     let mut app_id_buf = [0u8; 64];
     let mut has_manifest_id = false;
+    let mut requested_permissions = 0u32;
     {
         let mut manifest_path_buf = [0u8; 280];
         manifest_path_from_elf(path, manifest_path_buf.as_mut_ptr() as *mut c_char, manifest_path_buf.len());
@@ -350,7 +363,8 @@ pub unsafe extern "C" fn elf_app_load(
             manifest.as_mut_ptr(),
         ) == ESP_OK {
             let manifest = manifest.assume_init();
-            let id_len = manifest.id.iter().position(|&b| b == 0).unwrap_or(64);
+            requested_permissions = manifest.permissions;
+            let id_len = manifest.id.iter().position(|&b| b == 0).unwrap_or(63).min(63);
             if id_len > 0 {
                 app_id_buf[..id_len].copy_from_slice(&manifest.id[..id_len]);
                 has_manifest_id = true;
@@ -376,27 +390,29 @@ pub unsafe extern "C" fn elf_app_load(
             Err(_) => ESP_ERR_NOT_FOUND,
         }
     };
-    if sig_ret == ESP_OK {
+    let signed = if sig_ret == ESP_OK {
         esp_log_write(ESP_LOG_INFO, TAG.as_ptr(), b"ELF signature verified: %s\0".as_ptr(), path);
-        permissions_grant(perm_id, PERM_ALL);
+        true
     } else if sig_ret == ESP_ERR_NOT_FOUND {
-        // Unsigned ELF — refuse in production, allow with zero permissions in debug
+        // Unsigned ELF — refuse in production; debug builds receive IPC only.
         #[cfg(not(debug_assertions))]
         {
             esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"ELF unsigned: %s (REFUSED - production)\0".as_ptr(), path);
             free(buf);
-            return ESP_ERR_INVALID_CRC;
+            return sig_ret;
         }
         #[cfg(debug_assertions)]
         {
-            esp_log_write(ESP_LOG_WARN, TAG.as_ptr(), b"ELF unsigned: %s (dev mode, no permissions)\0".as_ptr(), path);
-            // Zero permissions — unsigned apps cannot access any resources
+            esp_log_write(ESP_LOG_WARN, TAG.as_ptr(), b"ELF unsigned: %s (dev mode, IPC only)\0".as_ptr(), path);
+            false
         }
     } else {
         esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"ELF signature INVALID: %s\0".as_ptr(), path);
         free(buf);
-        return ESP_ERR_INVALID_CRC;
-    }
+        return sig_ret;
+    };
+
+    let granted_permissions = effective_app_permissions(signed, requested_permissions);
 
     // 4. Init esp_elf context
     let mut state = match STATE.lock() {
@@ -425,7 +441,25 @@ pub unsafe extern "C" fn elf_app_load(
         sym_count as c_int,
     );
 
-    elf_set_symbol_resolver(thistle_symbol_resolver);
+    // Clear stale grants for a reused identity, then install only the trust-
+    // appropriate permission set before relocation resolves imports.
+    let _ = permissions_revoke(perm_id, PERM_ALL);
+    let grant_ret = if granted_permissions == 0 {
+        ESP_OK
+    } else {
+        permissions_grant(perm_id, granted_permissions)
+    };
+    if grant_ret != ESP_OK {
+        free(buf);
+        esp_elf_deinit(elf_ptr);
+        return grant_ret;
+    }
+
+    elf_set_symbol_resolver(if signed {
+        signed_app_symbol_resolver
+    } else {
+        unsigned_app_symbol_resolver
+    });
 
     syscall_set_current_app(perm_id);
     let ret = esp_elf_relocate(elf_ptr, buf as *const u8);
@@ -435,6 +469,7 @@ pub unsafe extern "C" fn elf_app_load(
 
     if ret != ESP_OK {
         esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"esp_elf_relocate failed: %s\0".as_ptr(), path);
+        let _ = permissions_revoke(perm_id, granted_permissions);
         esp_elf_deinit(elf_ptr);
         return ret;
     }
@@ -452,6 +487,7 @@ pub unsafe extern "C" fn elf_app_load(
             let manifest = manifest.assume_init();
             if !manifest_is_compatible(&manifest, CURRENT_ARCH.as_ptr() as *const c_char) {
                 esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"App incompatible: %s\0".as_ptr(), path);
+                let _ = permissions_revoke(perm_id, granted_permissions);
                 esp_elf_deinit(elf_ptr);
                 return ESP_ERR_NOT_SUPPORTED;
             }
@@ -464,6 +500,11 @@ pub unsafe extern "C" fn elf_app_load(
     let copy_len = path_bytes.len().min(app.path.len() - 1);
     app.path[..copy_len].copy_from_slice(&path_bytes[..copy_len]);
     app.path[copy_len] = 0;
+    let identity_bytes = CStr::from_ptr(perm_id).to_bytes();
+    let identity_len = identity_bytes.len().min(app.app_id.len() - 1);
+    app.app_id[..identity_len].copy_from_slice(&identity_bytes[..identity_len]);
+    app.app_id[identity_len] = 0;
+    app.granted_permissions = granted_permissions;
     app.loaded  = true;
     app.running = false;
     app.task    = std::ptr::null_mut();
@@ -538,6 +579,14 @@ pub unsafe extern "C" fn elf_app_unload(handle: *mut ElfAppHandle) -> i32 {
         let elf_ptr = app.elf_storage.as_mut_ptr() as *mut c_void;
         esp_elf_deinit(elf_ptr);
         app.loaded = false;
+    }
+
+    if app.granted_permissions != 0 && app.app_id[0] != 0 {
+        let _ = permissions_revoke(
+            app.app_id.as_ptr() as *const c_char,
+            app.granted_permissions,
+        );
+        app.granted_permissions = 0;
     }
 
     esp_log_write(ESP_LOG_INFO, TAG.as_ptr(), b"ELF app unloaded\0".as_ptr());
@@ -840,6 +889,7 @@ pub unsafe extern "C" fn elf_app_scan_and_register() -> c_int {
                     b"No manifest for app ELF '%s', skipping registration\0".as_ptr(),
                     full_path_ptr,
                 );
+                let _ = elf_app_unload(handle);
                 continue;
             }
 
@@ -854,6 +904,7 @@ pub unsafe extern "C" fn elf_app_scan_and_register() -> c_int {
                     b"App ELF '%s' has empty manifest id, skipping\0".as_ptr(),
                     full_path_ptr,
                 );
+                let _ = elf_app_unload(handle);
                 continue;
             }
 
@@ -861,7 +912,10 @@ pub unsafe extern "C" fn elf_app_scan_and_register() -> c_int {
             let reg_slot = {
                 let mut regs = match REG_MUTEX.lock() {
                     Ok(r) => r,
-                    Err(_) => continue,
+                    Err(_) => {
+                        let _ = elf_app_unload(handle);
+                        continue;
+                    }
                 };
                 let r = ensure_regs(&mut regs);
                 match r.iter().position(|r| !r.used) {
@@ -873,6 +927,7 @@ pub unsafe extern "C" fn elf_app_scan_and_register() -> c_int {
                             b"No free registration slots for app '%s'\0".as_ptr(),
                             full_path_ptr,
                         );
+                        let _ = elf_app_unload(handle);
                         continue;
                     }
                 }
@@ -882,7 +937,10 @@ pub unsafe extern "C" fn elf_app_scan_and_register() -> c_int {
             {
                 let mut strings = match REG_STR_MUTEX.lock() {
                     Ok(s) => s,
-                    Err(_) => continue,
+                    Err(_) => {
+                        let _ = elf_app_unload(handle);
+                        continue;
+                    }
                 };
                 let s = &mut ensure_reg_strings(&mut strings)[reg_slot];
                 let copy_id = id_len.min(s.id.len() - 1);
@@ -898,7 +956,10 @@ pub unsafe extern "C" fn elf_app_scan_and_register() -> c_int {
             let (id_ptr, name_ptr) = {
                 let mut strings = match REG_STR_MUTEX.lock() {
                     Ok(s) => s,
-                    Err(_) => continue,
+                    Err(_) => {
+                        let _ = elf_app_unload(handle);
+                        continue;
+                    }
                 };
                 let strs = ensure_reg_strings(&mut strings);
                 (
@@ -910,7 +971,10 @@ pub unsafe extern "C" fn elf_app_scan_and_register() -> c_int {
             {
                 let mut regs = match REG_MUTEX.lock() {
                     Ok(r) => r,
-                    Err(_) => continue,
+                    Err(_) => {
+                        let _ = elf_app_unload(handle);
+                        continue;
+                    }
                 };
                 let reg = &mut ensure_regs(&mut regs)[reg_slot];
 
@@ -937,7 +1001,10 @@ pub unsafe extern "C" fn elf_app_scan_and_register() -> c_int {
             let entry_ptr = {
                 let mut regs = match REG_MUTEX.lock() {
                     Ok(r) => r,
-                    Err(_) => continue,
+                    Err(_) => {
+                        let _ = elf_app_unload(handle);
+                        continue;
+                    }
                 };
                 &ensure_regs(&mut regs)[reg_slot].entry as *const CAppEntry
             };
@@ -955,14 +1022,14 @@ pub unsafe extern "C" fn elf_app_scan_and_register() -> c_int {
                 if let Ok(mut regs) = REG_MUTEX.lock() {
                     ensure_regs(&mut regs)[reg_slot] = ElfAppRegistration::empty();
                 }
+                let _ = elf_app_unload(handle);
                 continue;
             }
 
-            // 7. Grant permissions from manifest
-            let perms = c_manifest.permissions;
-            if perms != 0 {
-                permissions_grant(id_ptr, perms);
-            }
+            // Permissions were fixed before relocation from signature trust
+            // and the manifest. Never re-grant raw manifest bits here, since
+            // an unsigned debug app must remain IPC-only.
+            let perms = (*handle).granted_permissions;
 
             esp_log_write(
                 ESP_LOG_INFO,
@@ -983,4 +1050,29 @@ pub unsafe extern "C" fn elf_app_scan_and_register() -> c_int {
     );
 
     registered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsigned_manifest_cannot_escalate_beyond_ipc() {
+        assert_eq!(effective_app_permissions(false, PERM_ALL), PERM_IPC);
+        assert_eq!(effective_app_permissions(false, 0), PERM_IPC);
+    }
+
+    #[test]
+    fn signed_manifest_keeps_only_requested_permissions() {
+        assert_eq!(effective_app_permissions(true, PERM_ALL), PERM_ALL);
+        assert_eq!(effective_app_permissions(true, PERM_IPC), PERM_IPC);
+        assert_eq!(effective_app_permissions(true, 0), 0);
+    }
+
+    #[test]
+    fn empty_handle_owns_no_identity_or_permissions() {
+        let app = ElfAppHandle::empty();
+        assert_eq!(app.app_id, [0u8; 64]);
+        assert_eq!(app.granted_permissions, 0);
+    }
 }

--- a/components/kernel_rs/src/syscall_table.rs
+++ b/components/kernel_rs/src/syscall_table.rs
@@ -17,6 +17,98 @@ use crate::permissions::{self, *};
 
 static CURRENT_APP_ID: Mutex<[u8; 64]> = Mutex::new([0u8; 64]);
 
+// Explicit app ABI allowlists. Driver ELFs use the full table; signed apps
+// receive only documented `thistle_*` wrappers, and unsigned debug apps are
+// restricted to the IPC-only development surface.
+const UNSIGNED_APP_SYMBOLS: &[&str] = &["thistle_msg_recv", "thistle_msg_send"];
+
+const APP_VISIBLE_SYMBOLS: &[&str] = &[
+    "thistle_crypto_aes128_ecb_decrypt",
+    "thistle_crypto_aes128_ecb_encrypt",
+    "thistle_crypto_aes256_cbc_decrypt",
+    "thistle_crypto_aes256_cbc_encrypt",
+    "thistle_crypto_ed25519_derive_public",
+    "thistle_crypto_ed25519_keygen",
+    "thistle_crypto_ed25519_sign",
+    "thistle_crypto_ed25519_verify",
+    "thistle_crypto_hmac_sha256",
+    "thistle_crypto_hmac_verify",
+    "thistle_crypto_pbkdf2_sha256",
+    "thistle_crypto_random",
+    "thistle_crypto_sha256",
+    "thistle_crypto_x25519_key_exchange",
+    "thistle_delay",
+    "thistle_display_get_height",
+    "thistle_display_get_width",
+    "thistle_event_publish",
+    "thistle_event_subscribe",
+    "thistle_free",
+    "thistle_fs_close",
+    "thistle_fs_open",
+    "thistle_fs_read",
+    "thistle_fs_write",
+    "thistle_gps_enable",
+    "thistle_gps_get_position",
+    "thistle_input_register_cb",
+    "thistle_log",
+    "thistle_malloc",
+    "thistle_mesh_clear_inbox",
+    "thistle_mesh_deinit",
+    "thistle_mesh_find_contact",
+    "thistle_mesh_get_contact",
+    "thistle_mesh_get_contact_count",
+    "thistle_mesh_get_inbox_count",
+    "thistle_mesh_get_inbox_message",
+    "thistle_mesh_get_self_key",
+    "thistle_mesh_get_self_name",
+    "thistle_mesh_get_stats",
+    "thistle_mesh_init",
+    "thistle_mesh_loop",
+    "thistle_mesh_send",
+    "thistle_mesh_send_advert",
+    "thistle_mesh_send_advert_pos",
+    "thistle_millis",
+    "thistle_msg_recv",
+    "thistle_msg_send",
+    "thistle_power_get_battery_mv",
+    "thistle_power_get_battery_pct",
+    "thistle_radio_send",
+    "thistle_radio_set_freq",
+    "thistle_radio_start_rx",
+    "thistle_realloc",
+    "thistle_ui_create_button",
+    "thistle_ui_create_container",
+    "thistle_ui_create_label",
+    "thistle_ui_create_text_input",
+    "thistle_ui_destroy",
+    "thistle_ui_get_app_root",
+    "thistle_ui_get_text",
+    "thistle_ui_on_event",
+    "thistle_ui_set_align",
+    "thistle_ui_set_bg_color",
+    "thistle_ui_set_border_width",
+    "thistle_ui_set_flex_grow",
+    "thistle_ui_set_font_size",
+    "thistle_ui_set_gap",
+    "thistle_ui_set_layout",
+    "thistle_ui_set_one_line",
+    "thistle_ui_set_padding",
+    "thistle_ui_set_password_mode",
+    "thistle_ui_set_placeholder",
+    "thistle_ui_set_pos",
+    "thistle_ui_set_radius",
+    "thistle_ui_set_scrollable",
+    "thistle_ui_set_size",
+    "thistle_ui_set_text",
+    "thistle_ui_set_text_color",
+    "thistle_ui_set_visible",
+    "thistle_ui_theme_bg",
+    "thistle_ui_theme_primary",
+    "thistle_ui_theme_surface",
+    "thistle_ui_theme_text",
+    "thistle_ui_theme_text_secondary",
+];
+
 /// Set the ID of the app currently resolving symbols.
 /// Used by elf_loader to enforce permissions during relocation.
 #[no_mangle]
@@ -751,66 +843,73 @@ pub extern "C" fn syscall_table_count() -> usize {
     SYSCALL_TABLE.len()
 }
 
-/// Look up a symbol by name. Returns its address or NULL if not found or denied.
-///
-/// # Safety
-/// `name` must be a valid null-terminated C string.
-#[no_mangle]
-pub unsafe extern "C" fn syscall_resolve(name: *const c_char) -> *mut c_void {
+unsafe fn find_entry(name: *const c_char) -> Option<&'static SyscallEntry> {
     if name.is_null() {
-        return std::ptr::null_mut();
+        return None;
     }
 
     let name_str = match CStr::from_ptr(name).to_str() {
         Ok(s) => s,
-        Err(_) => return std::ptr::null_mut(),
+        Err(_) => return None,
     };
 
-    // Binary search for efficiency (O(log N))
     let result = SYSCALL_TABLE.binary_search_by(|probe| {
         let entry_name = CStr::from_ptr(probe.name).to_str().unwrap_or("");
         entry_name.cmp(name_str)
     });
 
-    let idx = match result {
-        Ok(i) => i,
-        Err(_) => {
-            #[cfg(not(test))]
-            esp_log_write(
-                2, // WARN
-                b"syscall\0".as_ptr(),
-                b"syscall_resolve: unknown symbol '%s'\0".as_ptr(),
-                name,
-            );
-            return std::ptr::null_mut();
-        }
-    };
+    result.ok().map(|idx| &SYSCALL_TABLE[idx])
+}
 
-    let entry = &SYSCALL_TABLE[idx];
-
-    // Permission check
+unsafe fn app_permission_allows(entry: &SyscallEntry) -> bool {
     if entry.permission != 0 {
         let app_id_bytes = CURRENT_APP_ID.lock().unwrap();
-        if app_id_bytes[0] != 0 {
-            let app_id = CStr::from_ptr(app_id_bytes.as_ptr() as *const c_char)
-                .to_str()
-                .unwrap_or("");
-
-            if !permissions::check(app_id, entry.permission) {
-                #[cfg(not(test))]
-                esp_log_write(
-                    1, // ERROR
-                    b"syscall\0".as_ptr(),
-                    b"syscall_resolve: PERMISSION DENIED for app '%s' to call '%s'\0".as_ptr(),
-                    app_id_bytes.as_ptr(),
-                    name,
-                );
-                return std::ptr::null_mut();
-            }
+        if app_id_bytes[0] == 0 {
+            return false;
         }
+        let app_id = CStr::from_ptr(app_id_bytes.as_ptr() as *const c_char)
+            .to_str()
+            .unwrap_or("");
+        return permissions::check(app_id, entry.permission);
     }
+    true
+}
 
-    entry.func_ptr as *mut c_void
+unsafe fn resolve_app_symbol(name: *const c_char, allowed: &[&str]) -> *mut c_void {
+    let name_str = match (!name.is_null()).then(|| CStr::from_ptr(name).to_str()) {
+        Some(Ok(s)) => s,
+        _ => return std::ptr::null_mut(),
+    };
+    if allowed.binary_search(&name_str).is_err() {
+        return std::ptr::null_mut();
+    }
+    match find_entry(name) {
+        Some(entry) if app_permission_allows(entry) => entry.func_ptr as *mut c_void,
+        _ => std::ptr::null_mut(),
+    }
+}
+
+/// Resolve a symbol for a privileged driver ELF. This is the only resolver
+/// that exposes raw HAL and RTOS primitives.
+///
+/// # Safety
+/// `name` must be a valid null-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn syscall_resolve(name: *const c_char) -> *mut c_void {
+    find_entry(name)
+        .map(|entry| entry.func_ptr as *mut c_void)
+        .unwrap_or(std::ptr::null_mut())
+}
+
+/// Resolve a symbol for a signed app, constrained to the documented app ABI
+/// and the permissions granted to the current manifest identity.
+pub unsafe fn syscall_resolve_signed_app(name: *const c_char) -> *mut c_void {
+    resolve_app_symbol(name, APP_VISIBLE_SYMBOLS)
+}
+
+/// Resolve a symbol for an unsigned debug app. Only IPC is linkable.
+pub unsafe fn syscall_resolve_unsigned_app(name: *const c_char) -> *mut c_void {
+    resolve_app_symbol(name, UNSIGNED_APP_SYMBOLS)
 }
 
 // ---------------------------------------------------------------------------
@@ -838,6 +937,84 @@ mod tests {
     }
 
     #[test]
+    fn test_app_resolver_allowlists_are_sorted() {
+        let source = include_str!("syscall_table.rs");
+        for symbols in [APP_VISIBLE_SYMBOLS, UNSIGNED_APP_SYMBOLS] {
+            for pair in symbols.windows(2) {
+                assert!(pair[0] < pair[1], "app allowlist is not sorted");
+            }
+            for name in symbols {
+                assert!(
+                    source.contains(&format!("entry!(\"{name}\"")),
+                    "app ABI symbol is absent from syscall table source: {name}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_every_syscall_has_an_explicit_caller_class() {
+        for entry in SYSCALL_TABLE {
+            let name = unsafe { CStr::from_ptr(entry.name).to_str().unwrap() };
+            let signed_app = APP_VISIBLE_SYMBOLS.binary_search(&name).is_ok();
+            let unsigned_app = UNSIGNED_APP_SYMBOLS.binary_search(&name).is_ok();
+
+            if signed_app {
+                assert!(name.starts_with("thistle_"), "non-wrapper exposed to app: {name}");
+                assert_ne!(name, "thistle_driver_get_config");
+            }
+            if unsigned_app {
+                assert!(signed_app, "unsigned ABI must be a subset of signed ABI");
+                assert_eq!(entry.permission, PERM_IPC, "unsigned ABI must require IPC");
+            }
+            // Entries absent from APP_VISIBLE_SYMBOLS are explicitly
+            // driver-only, including every raw HAL, logging, and RTOS symbol.
+        }
+    }
+
+    #[test]
+    fn test_apps_cannot_resolve_driver_hal_logging_or_rtos_primitives() {
+        for name in [
+            "esp_log_write",
+            "hal_get_registry",
+            "hal_display_register",
+            "hal_bus_register_spi",
+            "hal_bus_register_i2c",
+            "vTaskDelete",
+            "xTaskCreatePinnedToCore",
+            "xQueueGenericCreate",
+            "xQueueGenericSend",
+            "xQueueReceive",
+            "thistle_driver_get_config",
+        ] {
+            let c_name = std::ffi::CString::new(name).unwrap();
+            assert!(unsafe { syscall_resolve_signed_app(c_name.as_ptr()) }.is_null());
+            assert!(unsafe { syscall_resolve_unsigned_app(c_name.as_ptr()) }.is_null());
+        }
+    }
+
+    #[test]
+    fn test_unsigned_app_resolves_only_ipc() {
+        permissions::init();
+        permissions::grant("app.unsigned", PERM_IPC);
+        let app_id = std::ffi::CString::new("app.unsigned").unwrap();
+        unsafe { syscall_set_current_app(app_id.as_ptr()) };
+
+        for entry in SYSCALL_TABLE {
+            let name = unsafe { CStr::from_ptr(entry.name).to_str().unwrap() };
+            let c_name = std::ffi::CString::new(name).unwrap();
+            let resolved = unsafe { syscall_resolve_unsigned_app(c_name.as_ptr()) };
+            assert_eq!(
+                !resolved.is_null(),
+                UNSIGNED_APP_SYMBOLS.binary_search(&name).is_ok(),
+                "unsigned resolver policy mismatch for {name}"
+            );
+        }
+
+        unsafe { syscall_set_current_app(std::ptr::null()) };
+    }
+
+    #[test]
     fn test_resolve_thistle_delay() {
         let name = b"thistle_delay\0";
         let ptr = unsafe { syscall_resolve(name.as_ptr() as *const c_char) };
@@ -860,7 +1037,7 @@ mod tests {
         unsafe { syscall_set_current_app(app_id.as_ptr()) };
 
         let sym = std::ffi::CString::new("thistle_fs_open").unwrap();
-        let denied = unsafe { syscall_resolve(sym.as_ptr()) };
+        let denied = unsafe { syscall_resolve_signed_app(sym.as_ptr()) };
         assert!(denied.is_null(), "protected syscall must be denied without permissions");
 
         unsafe { syscall_set_current_app(std::ptr::null()) };
@@ -874,7 +1051,7 @@ mod tests {
         unsafe { syscall_set_current_app(app_id.as_ptr()) };
 
         let sym = std::ffi::CString::new("thistle_fs_open").unwrap();
-        let resolved = unsafe { syscall_resolve(sym.as_ptr()) };
+        let resolved = unsafe { syscall_resolve_signed_app(sym.as_ptr()) };
         assert!(!resolved.is_null(), "protected syscall must resolve after permission grant");
 
         unsafe { syscall_set_current_app(std::ptr::null()) };

--- a/components/kernel_rs/src/syscall_table.rs
+++ b/components/kernel_rs/src/syscall_table.rs
@@ -170,8 +170,8 @@ extern "C" {
     fn hal_set_board_name(name: *const c_char);
 
     // HAL bus
-    fn hal_bus_register_spi(bus: *const c_void) -> i32;
-    fn hal_bus_register_i2c(bus: *const c_void) -> i32;
+    fn hal_bus_register_spi(host_id: i32, bus_handle: *mut c_void) -> i32;
+    fn hal_bus_register_i2c(port: i32, bus_handle: *mut c_void) -> i32;
     fn hal_bus_get_spi(id: u32) -> *const c_void;
     fn hal_bus_get_i2c(id: u32) -> *const c_void;
 
@@ -631,8 +631,8 @@ static SYSCALL_TABLE: &[SyscallEntry] = &[
     entry!("hal_audio_register",            hal_audio_register                  as unsafe extern "C" fn(*const c_void, *const c_void) -> i32),
     entry!("hal_bus_get_i2c",               hal_bus_get_i2c                     as unsafe extern "C" fn(u32) -> *const c_void),
     entry!("hal_bus_get_spi",               hal_bus_get_spi                     as unsafe extern "C" fn(u32) -> *const c_void),
-    entry!("hal_bus_register_i2c",          hal_bus_register_i2c                as unsafe extern "C" fn(*const c_void) -> i32),
-    entry!("hal_bus_register_spi",          hal_bus_register_spi                as unsafe extern "C" fn(*const c_void) -> i32),
+    entry!("hal_bus_register_i2c",          hal_bus_register_i2c                as unsafe extern "C" fn(i32, *mut c_void) -> i32),
+    entry!("hal_bus_register_spi",          hal_bus_register_spi                as unsafe extern "C" fn(i32, *mut c_void) -> i32),
     entry!("hal_display_register",          hal_display_register                as unsafe extern "C" fn(*const c_void, *const c_void) -> i32),
     entry!("hal_get_registry",              hal_get_registry                    as unsafe extern "C" fn() -> *const c_void),
     entry!("hal_gps_register",              hal_gps_register                    as unsafe extern "C" fn(*const c_void, *const c_void) -> i32),
@@ -742,8 +742,8 @@ static SYSCALL_TABLE: &[SyscallEntry] = &[
     entry!("hal_audio_register",            hal_audio_register                as unsafe extern "C" fn(*const c_void, *const c_void) -> i32),
     entry!("hal_bus_get_i2c",               hal_bus_get_i2c                     as unsafe extern "C" fn(u32) -> *const c_void),
     entry!("hal_bus_get_spi",               hal_bus_get_spi                     as unsafe extern "C" fn(u32) -> *const c_void),
-    entry!("hal_bus_register_i2c",          hal_bus_register_i2c                as unsafe extern "C" fn(*const c_void) -> i32),
-    entry!("hal_bus_register_spi",          hal_bus_register_spi                as unsafe extern "C" fn(*const c_void) -> i32),
+    entry!("hal_bus_register_i2c",          hal_bus_register_i2c                as unsafe extern "C" fn(i32, *mut c_void) -> i32),
+    entry!("hal_bus_register_spi",          hal_bus_register_spi                as unsafe extern "C" fn(i32, *mut c_void) -> i32),
     entry!("hal_display_register",          hal_display_register                as unsafe extern "C" fn(*const c_void, *const c_void) -> i32),
     entry!("hal_get_registry",              hal_get_registry                    as unsafe extern "C" fn() -> *const c_void),
     entry!("hal_gps_register",              hal_gps_register                    as unsafe extern "C" fn(*const c_void, *const c_void) -> i32),
@@ -1012,6 +1012,34 @@ mod tests {
         }
 
         unsafe { syscall_set_current_app(std::ptr::null()) };
+    }
+
+    #[test]
+    fn test_driver_bus_registration_call_through_matches_public_abi() {
+        *crate::hal_registry::registry_mut() = crate::hal_registry::HalRegistry::new();
+        let mut spi_handle = 0x1234_u32;
+        let mut i2c_handle = 0x5678_u32;
+
+        for (name, bus_id, handle) in [
+            ("hal_bus_register_spi", 7, &mut spi_handle as *mut u32 as *mut c_void),
+            ("hal_bus_register_i2c", 3, &mut i2c_handle as *mut u32 as *mut c_void),
+        ] {
+            let c_name = std::ffi::CString::new(name).unwrap();
+            let address = unsafe { syscall_resolve(c_name.as_ptr()) };
+            assert!(!address.is_null(), "driver resolver lost {name}");
+            let register: unsafe extern "C" fn(i32, *mut c_void) -> i32 =
+                unsafe { std::mem::transmute(address) };
+            assert_eq!(unsafe { register(bus_id, handle) }, ESP_OK);
+        }
+
+        assert_eq!(
+            crate::hal_registry::hal_bus_get_spi(0),
+            &mut spi_handle as *mut u32 as *mut c_void
+        );
+        assert_eq!(
+            crate::hal_registry::hal_bus_get_i2c(0),
+            &mut i2c_handle as *mut u32 as *mut c_void
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- split privileged driver resolution from signed-app and unsigned-debug-app resolution
- expose signed apps only to an explicit documented wrapper allowlist, still gated by manifest permissions
- expose unsigned debug apps only to the two IPC calls, regardless of manifest claims
- reject HAL registration, registry, raw logging, driver configuration, queue, and task primitives for every app class
- bind permission grants to the loaded app handle, revoke them on unload, and clean up failed registrations
- remove the pre-relocation `PERM_ALL` grant and prevent unsigned manifests from escalating after registration
- correct both `hal_bus_register_*` declarations/casts to the public two-argument ABI and exercise them through resolved function pointers

## Validation

- complete Rust host suite: 1,294 passed
- resolver invariant suite passes in debug and `--release`
- SPI and I2C registration call-through ABI test passes with known IDs and handles
- `git diff --check`

## Stack

This draft is intentionally based on `codex/fix-signature-fail-open` / PR #80 because the trust decision is shared with app relocation. Review commits `2cc442a` and `4ae4543` for this PR.

Addresses #46, #47, #48, and #67. Keep those issues open until the ESP-IDF build and stacked integration are green.


