### PR TITLE
Replace guessed app-store HTTP ABI

### DIFF
--- a/components/kernel_rs/CMakeLists.txt
+++ b/components/kernel_rs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ThistleOS Rust kernel component (REQUIRED)
 
 idf_component_register(
-    SRCS "stub.c" "epaper_spi_shim.c"
+    SRCS "stub.c" "epaper_spi_shim.c" "http_client_shim.c"
     INCLUDE_DIRS "include"
     REQUIRES thistle_hal esp_timer freertos esp_partition fatfs vfs app_update
              esp_wifi esp_netif esp_event bt mbedtls esp_http_client

--- a/components/kernel_rs/http_client_shim.c
+++ b/components/kernel_rs/http_client_shim.c
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Typed C boundary for ESP-IDF's evolving HTTP client structs.
+
+#include "thistle_http_shim.h"
+
+#include <stddef.h>
+#include <stdlib.h>
+
+#include "esp_err.h"
+#include "esp_http_client.h"
+
+typedef struct {
+    esp_http_client_handle_t inner;
+    thistle_http_data_cb_t data_cb;
+    void *user_data;
+} thistle_http_client_t;
+
+#ifdef ESP_PLATFORM
+_Static_assert(sizeof(((esp_http_client_config_t *)0)->timeout_ms) == sizeof(int),
+               "ESP-IDF HTTP timeout ABI changed");
+_Static_assert(sizeof(((esp_http_client_event_t *)0)->data_len) == sizeof(int),
+               "ESP-IDF HTTP event length ABI changed");
+_Static_assert(offsetof(esp_http_client_event_t, client) <
+                   offsetof(esp_http_client_event_t, data),
+               "ESP-IDF HTTP event client/data order changed");
+_Static_assert(offsetof(esp_http_client_event_t, data) <
+                   offsetof(esp_http_client_event_t, data_len),
+               "ESP-IDF HTTP event data/length order changed");
+#endif
+
+#ifdef ESP_PLATFORM
+static esp_err_t thistle_http_event_handler(esp_http_client_event_t *event)
+{
+    thistle_http_client_t *client = event ? event->user_data : NULL;
+    if (!client || !client->data_cb || event->event_id != HTTP_EVENT_ON_DATA) {
+        return ESP_OK;
+    }
+    return client->data_cb((const uint8_t *)event->data,
+                           event->data_len,
+                           client->user_data);
+}
+#endif
+
+void *thistle_http_client_init(const char *url,
+                               int timeout_ms,
+                               thistle_http_data_cb_t data_cb,
+                               void *user_data)
+{
+    if (!url) {
+        return NULL;
+    }
+
+    thistle_http_client_t *client = calloc(1, sizeof(*client));
+    if (!client) {
+        return NULL;
+    }
+    client->data_cb = data_cb;
+    client->user_data = user_data;
+
+    const esp_http_client_config_t config = {
+        .url = url,
+#ifdef ESP_PLATFORM
+        .event_handler = thistle_http_event_handler,
+#endif
+        .user_data = client,
+        .timeout_ms = timeout_ms,
+    };
+    client->inner = esp_http_client_init(&config);
+    if (!client->inner) {
+        free(client);
+        return NULL;
+    }
+    return client;
+}
+
+static thistle_http_client_t *checked_client(void *opaque)
+{
+    return (thistle_http_client_t *)opaque;
+}
+
+int thistle_http_client_perform(void *opaque)
+{
+    thistle_http_client_t *client = checked_client(opaque);
+    if (!client) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    int result = esp_http_client_perform(client->inner);
+#ifndef ESP_PLATFORM
+    if (result == ESP_OK && client->data_cb) {
+        const char *data = sim_http_client_get_response_data(client->inner);
+        size_t length = sim_http_client_get_response_length(client->inner);
+        if (data && length > 0) {
+            result = client->data_cb((const uint8_t *)data,
+                                     (int)length,
+                                     client->user_data);
+        }
+    }
+#endif
+    return result;
+}
+
+int thistle_http_client_get_status_code(void *opaque)
+{
+    thistle_http_client_t *client = checked_client(opaque);
+    return client ? esp_http_client_get_status_code(client->inner) : 0;
+}
+
+int thistle_http_client_open(void *opaque, int write_len)
+{
+    thistle_http_client_t *client = checked_client(opaque);
+    return client ? esp_http_client_open(client->inner, write_len) : ESP_ERR_INVALID_ARG;
+}
+
+int64_t thistle_http_client_fetch_headers(void *opaque)
+{
+    thistle_http_client_t *client = checked_client(opaque);
+    return client ? esp_http_client_fetch_headers(client->inner) : -1;
+}
+
+int thistle_http_client_read(void *opaque, char *buffer, int length)
+{
+    thistle_http_client_t *client = checked_client(opaque);
+    return client ? esp_http_client_read(client->inner, buffer, length) : -1;
+}
+
+int thistle_http_client_close(void *opaque)
+{
+    thistle_http_client_t *client = checked_client(opaque);
+    return client ? esp_http_client_close(client->inner) : ESP_ERR_INVALID_ARG;
+}
+
+int thistle_http_client_cleanup(void *opaque)
+{
+    thistle_http_client_t *client = checked_client(opaque);
+    if (!client) {
+        return ESP_ERR_INVALID_ARG;
+    }
+#ifdef ESP_PLATFORM
+    int result = esp_http_client_cleanup(client->inner);
+#else
+    esp_http_client_cleanup(client->inner);
+    int result = ESP_OK;
+#endif
+    free(client);
+    return result;
+}

--- a/components/kernel_rs/include/thistle_http_shim.h
+++ b/components/kernel_rs/include/thistle_http_shim.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int (*thistle_http_data_cb_t)(const uint8_t *data,
+                                      int data_len,
+                                      void *user_data);
+
+void *thistle_http_client_init(const char *url,
+                               int timeout_ms,
+                               thistle_http_data_cb_t data_cb,
+                               void *user_data);
+int thistle_http_client_perform(void *client);
+int thistle_http_client_get_status_code(void *client);
+int thistle_http_client_open(void *client, int write_len);
+int64_t thistle_http_client_fetch_headers(void *client);
+int thistle_http_client_read(void *client, char *buffer, int length);
+int thistle_http_client_close(void *client);
+int thistle_http_client_cleanup(void *client);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/kernel_rs/src/appstore_client.rs
+++ b/components/kernel_rs/src/appstore_client.rs
@@ -45,70 +45,35 @@ const ESP_LOG_WARN:  i32 = 2;
 const ESP_LOG_ERROR: i32 = 1;
 
 // ---------------------------------------------------------------------------
-// esp_http_client FFI — same API on device (esp_http_client.h) and
-// simulator (sim_http.c shim).
+// Typed HTTP C shim. ESP-IDF owns all config/event structs; Rust crosses the
+// boundary only with stable primitive and opaque-pointer types.
 // ---------------------------------------------------------------------------
 
+type HttpDataCb = unsafe extern "C" fn(*const u8, c_int, *mut c_void) -> i32;
+
 extern "C" {
-    fn esp_http_client_init(config: *const EspHttpClientConfig) -> *mut c_void;
+    #[link_name = "thistle_http_client_init"]
+    fn http_client_init(
+        url: *const c_char,
+        timeout_ms: c_int,
+        data_cb: Option<HttpDataCb>,
+        user_data: *mut c_void,
+    ) -> *mut c_void;
+    #[link_name = "thistle_http_client_perform"]
     fn esp_http_client_perform(client: *mut c_void) -> i32;
+    #[link_name = "thistle_http_client_get_status_code"]
     fn esp_http_client_get_status_code(client: *mut c_void) -> c_int;
+    #[link_name = "thistle_http_client_cleanup"]
     fn esp_http_client_cleanup(client: *mut c_void) -> i32;
+    #[link_name = "thistle_http_client_open"]
     fn esp_http_client_open(client: *mut c_void, write_len: i32) -> i32;
-    fn esp_http_client_fetch_headers(client: *mut c_void) -> c_int;
+    #[link_name = "thistle_http_client_fetch_headers"]
+    fn esp_http_client_fetch_headers(client: *mut c_void) -> i64;
+    #[link_name = "thistle_http_client_read"]
     fn esp_http_client_read(client: *mut c_void, buf: *mut c_char, len: c_int) -> c_int;
+    #[link_name = "thistle_http_client_close"]
     fn esp_http_client_close(client: *mut c_void) -> i32;
 }
-
-// esp_http_client_config_t — only the fields we use; must be repr(C) padded to match.
-// We use a flexible approach: declare only the fields we set and pad to 128 bytes.
-#[repr(C)]
-struct EspHttpClientConfig {
-    url: *const c_char,
-    event_handler: Option<unsafe extern "C" fn(*mut EspHttpClientEvent) -> i32>,
-    user_data: *mut c_void,
-    timeout_ms: i32,
-    _pad: [u8; 84], // Pad to match ESP-IDF struct size (~128 bytes)
-}
-
-impl EspHttpClientConfig {
-    fn new(url: *const c_char, timeout_ms: i32) -> Self {
-        EspHttpClientConfig {
-            url,
-            event_handler: None,
-            user_data: std::ptr::null_mut(),
-            timeout_ms,
-            _pad: [0u8; 84],
-        }
-    }
-
-    fn with_handler(
-        url: *const c_char,
-        timeout_ms: i32,
-        handler: unsafe extern "C" fn(*mut EspHttpClientEvent) -> i32,
-        user_data: *mut c_void,
-    ) -> Self {
-        EspHttpClientConfig {
-            url,
-            event_handler: Some(handler),
-            user_data,
-            timeout_ms,
-            _pad: [0u8; 84],
-        }
-    }
-}
-
-// esp_http_client_event_t — minimal layout
-#[repr(C)]
-struct EspHttpClientEvent {
-    event_id: i32,      // HTTP_EVENT_ON_DATA = 5
-    data: *const u8,
-    data_len: i32,
-    user_data: *mut c_void,
-    // … more fields follow in the C struct, but we only read the above
-}
-
-const HTTP_EVENT_ON_DATA: i32 = 5;
 
 // ---------------------------------------------------------------------------
 // Signing FFI
@@ -510,21 +475,23 @@ impl HttpBuf {
     }
 }
 
-// http_buf_event_handler calls esp_log_write — excluded from test builds.
+// The C shim filters HTTP_EVENT_ON_DATA and passes only stable primitives.
 #[cfg(not(test))]
-unsafe extern "C" fn http_buf_event_handler(evt: *mut EspHttpClientEvent) -> i32 {
-    let resp = (*evt).user_data as *mut HttpBuf;
-    if resp.is_null() { return ESP_OK; }
+unsafe extern "C" fn http_buf_data_handler(
+    data: *const u8,
+    data_len: c_int,
+    user_data: *mut c_void,
+) -> i32 {
+    let resp = user_data as *mut HttpBuf;
+    if resp.is_null() || data.is_null() || data_len <= 0 { return ESP_OK; }
     let buf = &mut *resp;
 
-    if (*evt).event_id == HTTP_EVENT_ON_DATA {
-        let data = std::slice::from_raw_parts((*evt).data, (*evt).data_len as usize);
-        if buf.data.len() + data.len() < buf.capacity {
-            buf.data.extend_from_slice(data);
-        } else {
-            buf.overflow = true;
-            esp_log_write(ESP_LOG_WARN, TAG.as_ptr(), b"HTTP buffer overflow - truncated\0".as_ptr());
-        }
+    let bytes = std::slice::from_raw_parts(data, data_len as usize);
+    if buf.data.len() + bytes.len() <= buf.capacity {
+        buf.data.extend_from_slice(bytes);
+    } else {
+        buf.overflow = true;
+        esp_log_write(ESP_LOG_WARN, TAG.as_ptr(), b"HTTP buffer overflow - truncated\0".as_ptr());
     }
 
     ESP_OK
@@ -573,14 +540,12 @@ pub unsafe extern "C" fn appstore_fetch_catalog(
     let mut resp_buf = Box::new(HttpBuf::new(MAX_CATALOG_JSON + 1));
 
     let url_cstr = std::ffi::CString::new(url_str).unwrap_or_default();
-    let config = EspHttpClientConfig::with_handler(
+    let client = http_client_init(
         url_cstr.as_ptr(),
         15000,
-        http_buf_event_handler,
+        Some(http_buf_data_handler),
         &mut *resp_buf as *mut HttpBuf as *mut c_void,
     );
-
-    let client = esp_http_client_init(&config);
     if client.is_null() {
         return ESP_FAIL;
     }
@@ -794,8 +759,7 @@ pub unsafe extern "C" fn appstore_download_file(
         Err(_) => return ESP_ERR_INVALID_ARG,
     };
 
-    let config = EspHttpClientConfig::new(url_cstr.as_ptr(), 30000);
-    let client = esp_http_client_init(&config);
+    let client = http_client_init(url_cstr.as_ptr(), 30000, None, std::ptr::null_mut());
     if client.is_null() {
         return ESP_FAIL;
     }
@@ -1359,8 +1323,12 @@ pub unsafe extern "C" fn appstore_submit_rating(
         Err(_) => return ESP_FAIL,
     };
 
-    let config = EspHttpClientConfig::new(endpoint_cstr.as_ptr(), 10000);
-    let client = esp_http_client_init(&config);
+    let client = http_client_init(
+        endpoint_cstr.as_ptr(),
+        10000,
+        None,
+        std::ptr::null_mut(),
+    );
     if client.is_null() {
         return ESP_FAIL;
     }
@@ -1433,8 +1401,12 @@ pub unsafe extern "C" fn appstore_report_download(
         Err(_) => return ESP_FAIL,
     };
 
-    let config = EspHttpClientConfig::new(endpoint_cstr.as_ptr(), 10000);
-    let client = esp_http_client_init(&config);
+    let client = http_client_init(
+        endpoint_cstr.as_ptr(),
+        10000,
+        None,
+        std::ptr::null_mut(),
+    );
     if client.is_null() {
         return ESP_FAIL;
     }
@@ -1471,7 +1443,7 @@ pub unsafe extern "C" fn appstore_report_download(
 // Tests
 //
 // appstore_fetch_catalog(), appstore_download_file(), and
-// appstore_install_entry() all call esp_http_client_init (or esp_log_write)
+// appstore_install_entry() all call the HTTP client shim (or esp_log_write)
 // and are not safe on aarch64-apple-darwin. Test builds use guard-only stubs.
 //
 // The following are pure Rust and tested here:
@@ -1486,6 +1458,15 @@ pub unsafe extern "C" fn appstore_report_download(
 mod tests {
     use super::*;
     use std::ffi::CStr;
+
+    #[test]
+    fn test_http_ffi_has_no_approximate_esp_idf_structs() {
+        let source = include_str!("appstore_client.rs");
+        assert!(!source.contains(concat!("struct EspHttpClient", "Config")));
+        assert!(!source.contains(concat!("struct EspHttpClient", "Event")));
+        assert!(!source.contains(concat!("_pad:", " [u8;")));
+        assert!(source.contains("thistle_http_client_init"));
+    }
 
     // -----------------------------------------------------------------------
     // test_get_catalog_url_contains_thistle_apps

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -21,6 +21,8 @@ set(THISTLE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
 set(THISTLE_SRCS
     # HAL (registry moved to Rust — hal_registry.rs in kernel_rs)
     ${THISTLE_DIR}/components/thistle_hal/src/stub.c
+    # Typed HTTP boundary used by the Rust app-store client
+    ${THISTLE_DIR}/components/kernel_rs/http_client_shim.c
     # Widget API dispatch (Rust widget.rs → WM vtable bridge)
     ${THISTLE_DIR}/components/ui/src/widget_shims.c
     # thistle-tk WM C vtable + HAL bridge
@@ -245,9 +247,12 @@ add_executable(thistle_sim_tests
     tests/test_sim_main.c
     tests/test_sim_assert.c
     tests/test_i2c_bus.c
+    tests/test_http_client_shim.c
     sim_assert.c
     platform/sim_i2c_bus.c
     platform/sim_spi_bus.c
+    platform/sim_http.c
+    ${THISTLE_DIR}/components/kernel_rs/http_client_shim.c
     platform/platform_stubs.c
     devices/dev_pcf8563.c
     devices/dev_qmi8658c.c
@@ -263,6 +268,7 @@ target_include_directories(thistle_sim_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/tests
     ${THISTLE_DIR}/components/thistle_hal/include
+    ${THISTLE_DIR}/components/kernel_rs/include
 )
 
 target_compile_definitions(thistle_sim_tests PRIVATE
@@ -277,4 +283,4 @@ target_compile_options(thistle_sim_tests PRIVATE
     -Wno-unused-variable
 )
 
-target_link_libraries(thistle_sim_tests PRIVATE pthread m)
+target_link_libraries(thistle_sim_tests PRIVATE pthread m curl)

--- a/simulator/tests/test_http_client_shim.c
+++ b/simulator/tests/test_http_client_shim.c
@@ -1,0 +1,47 @@
+/* Simulator fixture tests for the typed HTTP client boundary. */
+#include "test_runner.h"
+#include "thistle_http_shim.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+typedef struct {
+    uint8_t data[128];
+    int length;
+} response_capture_t;
+
+static int capture_response(const uint8_t *data, int data_len, void *user_data)
+{
+    response_capture_t *capture = user_data;
+    if (!capture || !data || data_len < 0 || data_len > (int)sizeof(capture->data)) {
+        return -1;
+    }
+    memcpy(capture->data, data, (size_t)data_len);
+    capture->length = data_len;
+    return 0;
+}
+
+TEST(http_shim_delivers_fixture_bytes_status_and_cleanup) {
+    static const char fixture[] = "{\"apps\":[{\"id\":\"fixture\"}]}";
+    static const char path[] = "/tmp/thistle-http-shim-fixture.json";
+    static const char url[] = "file:///tmp/thistle-http-shim-fixture.json";
+
+    FILE *file = fopen(path, "wb");
+    ASSERT_TRUE(file != NULL);
+    ASSERT_EQ((int)fwrite(fixture, 1, sizeof(fixture) - 1, file),
+              (int)sizeof(fixture) - 1);
+    ASSERT_EQ(fclose(file), 0);
+
+    response_capture_t capture = {0};
+    void *client = thistle_http_client_init(url, 2500, capture_response, &capture);
+    ASSERT_TRUE(client != NULL);
+    ASSERT_EQ(thistle_http_client_perform(client), 0);
+    ASSERT_EQ(capture.length, (int)sizeof(fixture) - 1);
+    ASSERT_EQ(memcmp(capture.data, fixture, sizeof(fixture) - 1), 0);
+    /* libcurl file:// responses have no HTTP status, but the accessor must be safe. */
+    ASSERT_EQ(thistle_http_client_get_status_code(client), 0);
+    ASSERT_EQ(thistle_http_client_cleanup(client), 0);
+    ASSERT_EQ(unlink(path), 0);
+}

--- a/simulator/tests/test_sim_main.c
+++ b/simulator/tests/test_sim_main.c
@@ -25,6 +25,9 @@ extern void test_tca8418_key_injection(void);
 extern void test_cst328_no_touch(void);
 extern void test_cst328_touch_injection(void);
 
+/* test_http_client_shim.c */
+extern void test_http_shim_delivers_fixture_bytes_status_and_cleanup(void);
+
 int main(void)
 {
     printf("=== Simulator Unit Tests ===\n\n");
@@ -56,6 +59,9 @@ int main(void)
     printf("\n[cst328]\n");
     RUN_TEST(cst328_no_touch);
     RUN_TEST(cst328_touch_injection);
+
+    printf("\n[http_client_shim]\n");
+    RUN_TEST(http_shim_delivers_fixture_bytes_status_and_cleanup);
 
     TEST_SUMMARY();
     return _tests_failed > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary

- replace hand-written Rust copies of `esp_http_client_config_t` and `esp_http_client_event_t` with a typed C shim compiled against the active ESP-IDF headers
- initialize the real ESP-IDF config with designated fields and keep client/event layouts entirely on the C side
- bridge response data to Rust using only stable primitives and an opaque client handle
- add ESP-IDF compile-time assertions for timeout, event length, and the previously omitted `client`/`data` field ordering
- use the same shim in the simulator and add a fixture test for URL setup, response bytes, status access, and cleanup

## Validation

- complete Rust host suite: 1,279 passed
- simulator C fixture suite: 17/17 passed
- standalone shim compilation with `-Wall -Wextra -Werror`
- `git diff --check`

The isolated checkout did not contain the managed LVGL source needed for the full simulator executable; CI fetches that dependency and will run the normal simulator and ESP-IDF 5.5 builds.

Addresses #55. Keep the issue open until the ESP-IDF build and fixture checks are green.