### PR TITLE
Reject unsafe recovery catalog IDs

### DIFF
--- a/recovery/src/catalog_path.rs
+++ b/recovery/src/catalog_path.rs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) ThistleOS contributors
+
+use std::path::{Component, Path, PathBuf};
+
+pub const MAX_CATALOG_ID_LENGTH: usize = 63;
+
+/// Validate an untrusted catalog identifier before it becomes a filename.
+///
+/// Catalog IDs are a single ASCII component. Dots are retained for reverse-
+/// domain IDs, but dot segments and repeated dots are not permitted.
+pub fn validate_catalog_id(id: &str) -> Result<(), &'static str> {
+    let bytes = id.as_bytes();
+    if bytes.is_empty() || bytes.len() > MAX_CATALOG_ID_LENGTH {
+        return Err("catalog id has an invalid length");
+    }
+    if !bytes[0].is_ascii_lowercase() && !bytes[0].is_ascii_digit() {
+        return Err("catalog id must start with a lowercase letter or digit");
+    }
+    if !bytes[bytes.len() - 1].is_ascii_lowercase() && !bytes[bytes.len() - 1].is_ascii_digit() {
+        return Err("catalog id must end with a lowercase letter or digit");
+    }
+    if !bytes.iter().all(|byte| {
+        byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'.')
+    }) || id.contains("..")
+    {
+        return Err("catalog id must use the lowercase component grammar");
+    }
+    Ok(())
+}
+
+/// Construct one artifact destination and prove that its normalized parent is
+/// exactly the intended install root.
+pub fn catalog_destination(root: &str, id: &str, suffix: &str) -> Result<PathBuf, &'static str> {
+    validate_catalog_id(id)?;
+    let root = Path::new(root);
+    if !root.is_absolute()
+        || root
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err("catalog install root is not normalized");
+    }
+
+    let destination = root.join(format!("{id}{suffix}"));
+    if destination.parent() != Some(root)
+        || destination
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err("catalog destination escapes its install root");
+    }
+    Ok(destination)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_separators_dot_segments_absolute_prefixes_and_encoding_tricks() {
+        let overlong = "a".repeat(MAX_CATALOG_ID_LENGTH + 1);
+        for invalid in [
+            "",
+            ".",
+            "..",
+            "../driver",
+            "driver/child",
+            r"driver\child",
+            "/absolute",
+            "C:driver",
+            "%2e%2e%2fdriver",
+            "driver..child",
+            ".hidden",
+            "trailing.",
+            "UPPERCASE",
+            "non-ascii-é",
+            overlong.as_str(),
+        ] {
+            assert!(
+                validate_catalog_id(invalid).is_err(),
+                "accepted {invalid:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn valid_ids_resolve_under_each_type_specific_root() {
+        for (root, id, suffix, expected) in [
+            (
+                "/sdcard/config/boards",
+                "waveshare-esp32-s3-touch-amoled-2.06",
+                ".json",
+                "/sdcard/config/boards/waveshare-esp32-s3-touch-amoled-2.06.json",
+            ),
+            (
+                "/sdcard/drivers",
+                "com.thistle.drv.radio-sx1262",
+                ".drv.elf",
+                "/sdcard/drivers/com.thistle.drv.radio-sx1262.drv.elf",
+            ),
+            (
+                "/sdcard/wm",
+                "com.thistle.wm.thistle-tk",
+                ".wm.elf",
+                "/sdcard/wm/com.thistle.wm.thistle-tk.wm.elf",
+            ),
+        ] {
+            assert_eq!(
+                catalog_destination(root, id, suffix).unwrap(),
+                PathBuf::from(expected)
+            );
+        }
+    }
+}

--- a/recovery/src/main.rs
+++ b/recovery/src/main.rs
@@ -22,6 +22,7 @@ use esp_idf_svc::wifi::{
 
 use log::*;
 
+mod catalog_path;
 mod recovery_ota;
 mod recovery_web;
 

--- a/recovery/src/recovery_ota.rs
+++ b/recovery/src/recovery_ota.rs
@@ -7,6 +7,8 @@ use esp_idf_sys::*;
 use log::*;
 use std::sync::atomic::{AtomicU8, Ordering};
 
+use crate::catalog_path::{catalog_destination, validate_catalog_id};
+
 // ---------------------------------------------------------------------------
 // Chip detection
 // ---------------------------------------------------------------------------
@@ -1231,6 +1233,7 @@ pub fn recovery_download_board_bundle_for(
             Some(v) => v,
             None => continue,
         };
+        validate_catalog_id(&id).map_err(anyhow::Error::msg)?;
         let url = match json_extract_string(obj, "url") {
             Some(v) => v,
             None => continue,
@@ -1240,15 +1243,18 @@ pub fn recovery_download_board_bundle_for(
         let name = json_extract_string(obj, "name").unwrap_or_else(|| id.clone());
 
         let dest_path = match entry_type.as_str() {
-            "firmware" => String::new(),
-            "board" => format!("{}/{}.json", SD_BOARDS_DIR, id),
-            "driver" => format!("{}/{}.drv.elf", SD_DRIVERS_DIR, id),
-            "wm" => format!("{}/{}.wm.elf", SD_WM_DIR, id),
+            "firmware" => Ok(std::path::PathBuf::new()),
+            "board" => catalog_destination(SD_BOARDS_DIR, &id, ".json"),
+            "driver" => catalog_destination(SD_DRIVERS_DIR, &id, ".drv.elf"),
+            "wm" => catalog_destination(SD_WM_DIR, &id, ".wm.elf"),
             other => {
                 info!("Skipping '{}' (type={})", id, other);
                 continue;
             }
-        };
+        }
+        .map_err(anyhow::Error::msg)?
+        .to_string_lossy()
+        .into_owned();
 
         if entry_type == "firmware" {
             let Some(expected_sha) = expected_sha.as_deref().filter(|s| !s.is_empty()) else {


### PR DESCRIPTION
## What changed

- validates every catalog ID before any URL is fetched or destination is constructed
- restricts IDs to a bounded, lowercase, single-component grammar while retaining reverse-domain IDs
- rejects separators, dot segments, absolute prefixes, percent-encoded tricks, Unicode, uppercase, and overlong IDs
- constructs board, driver, and window-manager paths through one helper that proves the normalized parent is exactly the type-specific root
- adds standalone regression coverage for all three destination roots and representative valid catalog IDs

## Validation

- catalog path regression suite: 2 passed
- Recovery `cargo +esp check`: passed with ESP-IDF v5.5
- `git diff --check`: passed

Resolves #42.