### PR TITLE
Reject SMS AT command injection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,18 @@ jobs:
           echo "Total test cases (approximate):"
           grep -r "TEST_CASE" components/test_thistle/ | wc -l
 
+      - name: Test SMS command framing validation
+        run: |
+          cc -std=c11 -Wall -Wextra -Werror \
+            -Icomponents/drv_modem_a7682e/include \
+            components/drv_modem_a7682e/tests/test_sms_validation.c \
+            -o /tmp/test_sms_validation
+          /tmp/test_sms_validation
+          grep -q "esp_modem_send_sms" \
+            components/drv_modem_a7682e/src/drv_modem_a7682e.c
+          ! grep -Eq 'AT\\+CMGS=.*msg|AT\\+CMGS=.*\\\\r' \
+            components/drv_modem_a7682e/src/drv_modem_a7682e.c
+
   simulator-boot:
     name: Simulator Boot Test
     runs-on: ubuntu-latest

--- a/components/drv_modem_a7682e/include/a7682e_sms_validation.h
+++ b/components/drv_modem_a7682e/include/a7682e_sms_validation.h
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) ThistleOS contributors
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#define A7682E_SMS_PHONE_MAX_LENGTH 31U
+#define A7682E_SMS_MESSAGE_MAX_LENGTH 160U
+
+/* Phone numbers used in AT+CMGS may be international (+<digits>) or local
+ * (<digits>). Restricting the input to this grammar prevents AT syntax from
+ * entering the command's quoted recipient field. */
+static inline bool a7682e_sms_phone_is_valid(const char *phone)
+{
+    if (!phone) {
+        return false;
+    }
+
+    size_t length = 0;
+    while (length <= A7682E_SMS_PHONE_MAX_LENGTH && phone[length] != '\0') {
+        length++;
+    }
+    if (length == 0 || length > A7682E_SMS_PHONE_MAX_LENGTH) {
+        return false;
+    }
+
+    size_t index = phone[0] == '+' ? 1U : 0U;
+    if (index == length) {
+        return false;
+    }
+    for (; index < length; index++) {
+        if (phone[index] < '0' || phone[index] > '9') {
+            return false;
+        }
+    }
+    return true;
+}
+
+/* Text is sent only after esp_modem has observed the CMGS prompt. Reject C0
+ * controls, DEL, and quotes before invoking that API so hostile input cannot
+ * terminate, escape, or masquerade as command framing. */
+static inline bool a7682e_sms_message_is_valid(const char *message)
+{
+    if (!message) {
+        return false;
+    }
+
+    size_t length = 0;
+    while (length <= A7682E_SMS_MESSAGE_MAX_LENGTH && message[length] != '\0') {
+        unsigned char byte = (unsigned char)message[length];
+        if (byte < 0x20 || byte == 0x7f || byte == '"') {
+            return false;
+        }
+        length++;
+    }
+    return length <= A7682E_SMS_MESSAGE_MAX_LENGTH;
+}

--- a/components/drv_modem_a7682e/include/drv_modem_a7682e.h
+++ b/components/drv_modem_a7682e/include/drv_modem_a7682e.h
@@ -199,9 +199,9 @@ esp_err_t drv_a7682e_sms_init(void);
  * Temporarily switches to command mode if PPP is active, sends the message,
  * then restores PPP if it was active.
  *
- * @param phone  Destination phone number (E.164 format, e.g. "+15551234567").
- * @param msg    Message text (max 160 chars for GSM 7-bit encoding).
- * @return ESP_OK on success, ESP_ERR_INVALID_ARG if phone/msg is NULL,
+ * @param phone  Destination number: optional leading '+', then digits only.
+ * @param msg    Message text (max 160 chars; controls and quotes rejected).
+ * @return ESP_OK on success, ESP_ERR_INVALID_ARG if either field is unsafe,
  *         ESP_ERR_INVALID_STATE if modem is off.
  */
 esp_err_t drv_a7682e_send_sms(const char *phone, const char *msg);

--- a/components/drv_modem_a7682e/src/drv_modem_a7682e.c
+++ b/components/drv_modem_a7682e/src/drv_modem_a7682e.c
@@ -2,6 +2,7 @@
 // ThistleOS — Simcom A7682E 4G LTE modem driver (esp_modem backend)
 
 #include "drv_modem_a7682e.h"
+#include "a7682e_sms_validation.h"
 
 #include "esp_modem_api.h"
 #include "esp_modem_config.h"
@@ -551,15 +552,9 @@ restore:
 
 esp_err_t drv_a7682e_send_sms(const char *phone, const char *msg)
 {
-    if (!phone || !msg) {
-        return ESP_ERR_INVALID_ARG;
-    }
-    if (strlen(phone) >= 32) {
-        ESP_LOGE(TAG, "send_sms: phone number too long (max 31 chars)");
-        return ESP_ERR_INVALID_ARG;
-    }
-    if (strlen(msg) > 160) {
-        ESP_LOGE(TAG, "send_sms: message too long (max 160 chars for GSM 7-bit)");
+    if (!a7682e_sms_phone_is_valid(phone)
+        || !a7682e_sms_message_is_valid(msg)) {
+        ESP_LOGE(TAG, "send_sms: rejected unsafe recipient or message text");
         return ESP_ERR_INVALID_ARG;
     }
     if (!s_modem.dce || !s_modem.powered_on) {
@@ -572,27 +567,26 @@ esp_err_t drv_a7682e_send_sms(const char *phone, const char *msg)
         esp_modem_set_mode(s_modem.dce, ESP_MODEM_MODE_COMMAND);
     }
 
-    char resp[128] = {0};
-
     /* Ensure text mode is active before sending */
-    esp_modem_at(s_modem.dce, "AT+CMGF=1", resp, 2000);
-
-    /* Build combined AT+CMGS command with message body and Ctrl+Z terminator.
-     * The esp_modem AT handler passes the full string to the modem;
-     * the embedded \r triggers the ">" prompt and the modem reads the text
-     * up to the Ctrl+Z (0x1A) as the message body. */
-    char cmd[320] = {0};
-    snprintf(cmd, sizeof(cmd), "AT+CMGS=\"%s\"\r%s\x1A", phone, msg);
-
-    ESP_LOGI(TAG, "send_sms: sending to %s", phone);
-    esp_err_t ret = esp_modem_at(s_modem.dce, cmd, resp, 15000);
+    esp_err_t ret = esp_modem_sms_txt_mode(s_modem.dce, true);
     if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "send_sms: failed (%s), resp: %s",
-                 esp_err_to_name(ret), resp);
-    } else {
-        ESP_LOGI(TAG, "send_sms: sent successfully, resp: %s", resp);
+        ESP_LOGE(TAG, "send_sms: failed to enable text mode: %s",
+                 esp_err_to_name(ret));
+        goto restore;
     }
 
+    ESP_LOGI(TAG, "send_sms: sending to %s", phone);
+    /* esp_modem_send_sms performs the prompt-aware two-stage exchange: it
+     * submits the validated recipient command, waits for the CMGS prompt, and
+     * only then transmits the validated message body and terminator. */
+    ret = esp_modem_send_sms(s_modem.dce, phone, msg);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "send_sms: failed: %s", esp_err_to_name(ret));
+    } else {
+        ESP_LOGI(TAG, "send_sms: sent successfully");
+    }
+
+restore:
     if (ppp_was_active) {
         esp_modem_set_mode(s_modem.dce, ESP_MODEM_MODE_DATA);
     }

--- a/components/drv_modem_a7682e/tests/test_sms_validation.c
+++ b/components/drv_modem_a7682e/tests/test_sms_validation.c
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) ThistleOS contributors
+
+#include "a7682e_sms_validation.h"
+
+#include <assert.h>
+#include <string.h>
+
+static void test_phone_grammar(void)
+{
+    assert(a7682e_sms_phone_is_valid("+61412345678"));
+    assert(a7682e_sms_phone_is_valid("0412345678"));
+
+    const char *invalid[] = {
+        "",
+        "+",
+        "+61\";AT+CFUN=0",
+        "123\rAT+CFUN=0",
+        "123\nAT+CFUN=0",
+        "123\x1b" "AT",
+        "123\x1a" "AT",
+        "12 34",
+        "12-34",
+    };
+    for (size_t i = 0; i < sizeof(invalid) / sizeof(invalid[0]); i++) {
+        assert(!a7682e_sms_phone_is_valid(invalid[i]));
+    }
+
+    char overlong[A7682E_SMS_PHONE_MAX_LENGTH + 2U];
+    memset(overlong, '1', sizeof(overlong));
+    overlong[sizeof(overlong) - 1U] = '\0';
+    assert(!a7682e_sms_phone_is_valid(overlong));
+}
+
+static void test_message_controls(void)
+{
+    assert(a7682e_sms_message_is_valid("ordinary GSM text"));
+    assert(a7682e_sms_message_is_valid(""));
+
+    const char *invalid[] = {
+        "quoted \"payload\"",
+        "line\rAT+CFUN=0",
+        "line\nAT+CFUN=0",
+        "escape\x1b" "AT",
+        "terminate\x1a" "AT",
+        "delete\x7f" "AT",
+    };
+    for (size_t i = 0; i < sizeof(invalid) / sizeof(invalid[0]); i++) {
+        assert(!a7682e_sms_message_is_valid(invalid[i]));
+    }
+
+    char maximum[A7682E_SMS_MESSAGE_MAX_LENGTH + 1U];
+    memset(maximum, 'A', A7682E_SMS_MESSAGE_MAX_LENGTH);
+    maximum[A7682E_SMS_MESSAGE_MAX_LENGTH] = '\0';
+    assert(a7682e_sms_message_is_valid(maximum));
+
+    char overlong[A7682E_SMS_MESSAGE_MAX_LENGTH + 2U];
+    memset(overlong, 'A', sizeof(overlong));
+    overlong[sizeof(overlong) - 1U] = '\0';
+    assert(!a7682e_sms_message_is_valid(overlong));
+}
+
+int main(void)
+{
+    test_phone_grammar();
+    test_message_controls();
+    return 0;
+}


### PR DESCRIPTION
## What changed

- restricts recipients to an optional leading `+` followed by digits
- bounds recipient and message scans before modem state is touched
- rejects quotes, CR, LF, ESC, Ctrl-Z, DEL, and all other C0 controls in message text
- replaces the combined untrusted `AT+CMGS` command with Espressif's prompt-aware `esp_modem_send_sms` API
- switches text mode through the typed esp_modem API and preserves PPP restoration on failure
- adds host regression coverage and a CI assertion that combined command framing cannot return

## Validation

- host validation fixture: passed under C11 with `-Wall -Wextra -Werror`
- valid international and local numbers covered
- quote, CR, LF, ESC, Ctrl-Z, DEL, overlength, and malformed recipient cases covered
- prompt-aware API verified against the pinned Espressif esp_modem v1.3 implementation
- `git diff --check`: passed

The full ESP-IDF build remains the required CI integration gate.

Resolves #49.