### PR TITLE
Bound assistant request serialization

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,16 @@ jobs:
           ! grep -Eq 'AT\\+CMGS=.*msg|AT\\+CMGS=.*\\\\r' \
             components/drv_modem_a7682e/src/drv_modem_a7682e.c
 
+      - name: Test assistant request bounds under sanitizers
+        run: |
+          cc -std=c11 -Wall -Wextra -Werror \
+            -fsanitize=address,undefined -fno-omit-frame-pointer \
+            -Icomponents/apps_builtin/assistant \
+            components/apps_builtin/assistant/assistant_request.c \
+            components/apps_builtin/assistant/tests/test_assistant_request.c \
+            -o /tmp/test_assistant_request
+          /tmp/test_assistant_request
+
   simulator-boot:
     name: Simulator Boot Test
     runs-on: ubuntu-latest

--- a/components/apps_builtin/CMakeLists.txt
+++ b/components/apps_builtin/CMakeLists.txt
@@ -8,6 +8,7 @@ idf_component_register(
         "messenger/messenger_transport.c"
         "messenger/messenger_ui.c"
         "assistant/assistant_app.c"
+        "assistant/assistant_request.c"
         "assistant/assistant_ui.c"
         "terminal/terminal_app.c"
         "terminal/terminal_ui.c"

--- a/components/apps_builtin/assistant/assistant_request.c
+++ b/components/apps_builtin/assistant/assistant_request.c
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) ThistleOS contributors
+
+#include "assistant_request.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    char *buffer;
+    size_t capacity;
+    size_t length;
+    bool valid;
+} json_writer_t;
+
+static bool writer_reserve(json_writer_t *writer, size_t additional)
+{
+    if (!writer->valid || additional > SIZE_MAX - writer->length - 1U) {
+        writer->valid = false;
+        return false;
+    }
+    if (writer->buffer && writer->length + additional >= writer->capacity) {
+        writer->valid = false;
+        return false;
+    }
+    return true;
+}
+
+static bool writer_append_bytes(json_writer_t *writer,
+                                const char *bytes,
+                                size_t length)
+{
+    if (!writer_reserve(writer, length)) {
+        return false;
+    }
+    if (writer->buffer && length > 0) {
+        memcpy(writer->buffer + writer->length, bytes, length);
+    }
+    writer->length += length;
+    return true;
+}
+
+static bool writer_append_literal(json_writer_t *writer, const char *literal)
+{
+    return writer_append_bytes(writer, literal, strlen(literal));
+}
+
+static bool writer_append_char(json_writer_t *writer, char value)
+{
+    return writer_append_bytes(writer, &value, 1U);
+}
+
+static bool writer_append_json_string(json_writer_t *writer, const char *value)
+{
+    static const char hex[] = "0123456789abcdef";
+    if (!value || !writer_append_char(writer, '"')) {
+        return false;
+    }
+
+    for (const unsigned char *cursor = (const unsigned char *)value;
+         *cursor != '\0'; cursor++) {
+        const char *escape = NULL;
+        switch (*cursor) {
+            case '"': escape = "\\\""; break;
+            case '\\': escape = "\\\\"; break;
+            case '\b': escape = "\\b"; break;
+            case '\f': escape = "\\f"; break;
+            case '\n': escape = "\\n"; break;
+            case '\r': escape = "\\r"; break;
+            case '\t': escape = "\\t"; break;
+            default: break;
+        }
+        if (escape) {
+            if (!writer_append_bytes(writer, escape, 2U)) {
+                return false;
+            }
+        } else if (*cursor < 0x20U) {
+            char unicode_escape[6] = {
+                '\\', 'u', '0', '0', hex[*cursor >> 4], hex[*cursor & 0x0f]
+            };
+            if (!writer_append_bytes(writer, unicode_escape,
+                                     sizeof(unicode_escape))) {
+                return false;
+            }
+        } else if (!writer_append_char(writer, (char)*cursor)) {
+            return false;
+        }
+    }
+    return writer_append_char(writer, '"');
+}
+
+static bool write_request(json_writer_t *writer,
+                          const char *model,
+                          const char *system_prompt,
+                          const assistant_request_message_t *history,
+                          size_t history_count,
+                          const char *user_message)
+{
+    if (!model || !system_prompt || !user_message
+        || (history_count > 0 && !history)) {
+        return false;
+    }
+
+    if (!writer_append_literal(writer, "{\"model\":")
+        || !writer_append_json_string(writer, model)
+        || !writer_append_literal(writer,
+            ",\"max_tokens\":512,\"system\":")
+        || !writer_append_json_string(writer, system_prompt)
+        || !writer_append_literal(writer, ",\"messages\":[")) {
+        return false;
+    }
+
+    for (size_t index = 0; index < history_count; index++) {
+        if (!history[index].role || !history[index].content
+            || (index > 0 && !writer_append_char(writer, ','))
+            || !writer_append_literal(writer, "{\"role\":")
+            || !writer_append_json_string(writer, history[index].role)
+            || !writer_append_literal(writer, ",\"content\":")
+            || !writer_append_json_string(writer, history[index].content)
+            || !writer_append_char(writer, '}')) {
+            return false;
+        }
+    }
+
+    if ((history_count > 0 && !writer_append_char(writer, ','))
+        || !writer_append_literal(writer, "{\"role\":\"user\",\"content\":")
+        || !writer_append_json_string(writer, user_message)
+        || !writer_append_literal(writer, "}]}")) {
+        return false;
+    }
+    return writer->valid;
+}
+
+char *assistant_request_build(const char *model,
+                              const char *system_prompt,
+                              const assistant_request_message_t *history,
+                              size_t history_count,
+                              const char *user_message,
+                              size_t *out_length)
+{
+    if (!out_length) {
+        return NULL;
+    }
+    *out_length = 0;
+
+    json_writer_t measure = {
+        .buffer = NULL,
+        .capacity = 0,
+        .length = 0,
+        .valid = true,
+    };
+    if (!write_request(&measure, model, system_prompt, history, history_count,
+                       user_message)
+        || measure.length == SIZE_MAX) {
+        return NULL;
+    }
+
+    char *body = malloc(measure.length + 1U);
+    if (!body) {
+        return NULL;
+    }
+    json_writer_t writer = {
+        .buffer = body,
+        .capacity = measure.length + 1U,
+        .length = 0,
+        .valid = true,
+    };
+    if (!write_request(&writer, model, system_prompt, history, history_count,
+                       user_message)
+        || writer.length != measure.length) {
+        free(body);
+        return NULL;
+    }
+    body[writer.length] = '\0';
+    *out_length = writer.length;
+    return body;
+}

--- a/components/apps_builtin/assistant/assistant_request.h
+++ b/components/apps_builtin/assistant/assistant_request.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) ThistleOS contributors
+
+#pragma once
+
+#include <stddef.h>
+
+typedef struct {
+    const char *role;
+    const char *content;
+} assistant_request_message_t;
+
+/* Build one Messages API request as an exactly sized heap allocation.
+ * Returns NULL on invalid input, size overflow, or allocation failure. */
+char *assistant_request_build(const char *model,
+                              const char *system_prompt,
+                              const assistant_request_message_t *history,
+                              size_t history_count,
+                              const char *user_message,
+                              size_t *out_length);

--- a/components/apps_builtin/assistant/assistant_ui.c
+++ b/components/apps_builtin/assistant/assistant_ui.c
@@ -18,10 +18,13 @@
  * on app pause and loaded on app create.
  */
 #include "assistant/assistant_app.h"
+#include "assistant/assistant_request.h"
 
 #include "lvgl.h"
 #include "esp_log.h"
 #include "esp_timer.h"
+#include <limits.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
 #include <sys/stat.h>
@@ -388,48 +391,26 @@ static esp_err_t call_claude_api(const assistant_config_t *cfg,
      * Build JSON request body.
      * Include up to the last 6 messages for conversation context.
      * ------------------------------------------------------------------ */
-    char body[2048];
-    int pos = 0;
-
-    pos += snprintf(body + pos, sizeof(body) - pos,
-        "{\"model\":\"%s\",\"max_tokens\":512,\"system\":\"%s\",\"messages\":[",
-        cfg->model, cfg->system_prompt);
-
     int start = (s_ai.msg_count > 6) ? s_ai.msg_count - 6 : 0;
+    assistant_request_message_t history[6];
+    size_t history_count = 0;
     for (int i = start; i < s_ai.msg_count; i++) {
         int idx = i % MAX_MESSAGES;
-        const char *role = s_ai.messages[idx].is_user ? "user" : "assistant";
-        if (i > start) pos += snprintf(body + pos, sizeof(body) - pos, ",");
-
-        /* Inline-escape the message text: " → \", \ → \\, newline → \n */
-        char escaped[MAX_MSG_TEXT * 2];
-        size_t ep = 0;
-        for (const char *c = s_ai.messages[idx].text; *c && ep + 3 < sizeof(escaped); c++) {
-            if (*c == '"')       { escaped[ep++] = '\\'; escaped[ep++] = '"';  }
-            else if (*c == '\\') { escaped[ep++] = '\\'; escaped[ep++] = '\\'; }
-            else if (*c == '\n') { escaped[ep++] = '\\'; escaped[ep++] = 'n';  }
-            else                 { escaped[ep++] = *c; }
-        }
-        escaped[ep] = '\0';
-
-        pos += snprintf(body + pos, sizeof(body) - pos,
-            "{\"role\":\"%s\",\"content\":\"%s\"}", role, escaped);
+        history[history_count].role =
+            s_ai.messages[idx].is_user ? "user" : "assistant";
+        history[history_count].content = s_ai.messages[idx].text;
+        history_count++;
     }
 
-    /* Current user message — also escaped */
-    char escaped_msg[MAX_MSG_TEXT * 2];
-    size_t ep = 0;
-    for (const char *c = user_msg; *c && ep + 3 < sizeof(escaped_msg); c++) {
-        if (*c == '"')       { escaped_msg[ep++] = '\\'; escaped_msg[ep++] = '"';  }
-        else if (*c == '\\') { escaped_msg[ep++] = '\\'; escaped_msg[ep++] = '\\'; }
-        else if (*c == '\n') { escaped_msg[ep++] = '\\'; escaped_msg[ep++] = 'n';  }
-        else                 { escaped_msg[ep++] = *c; }
+    size_t body_len = 0;
+    char *body = assistant_request_build(
+        cfg->model, cfg->system_prompt, history, history_count, user_msg,
+        &body_len);
+    if (!body || body_len > INT_MAX) {
+        free(body);
+        ESP_LOGE(TAG, "Failed to build bounded assistant request");
+        return ESP_ERR_NO_MEM;
     }
-    escaped_msg[ep] = '\0';
-
-    if (s_ai.msg_count > start) pos += snprintf(body + pos, sizeof(body) - pos, ",");
-    pos += snprintf(body + pos, sizeof(body) - pos,
-        "{\"role\":\"user\",\"content\":\"%s\"}]}", escaped_msg);
 
     /* ------------------------------------------------------------------
      * HTTP POST
@@ -447,6 +428,7 @@ static esp_err_t call_claude_api(const assistant_config_t *cfg,
 
     esp_http_client_handle_t client = esp_http_client_init(&http_config);
     if (!client) {
+        free(body);
         ESP_LOGE(TAG, "Failed to init HTTP client");
         return ESP_FAIL;
     }
@@ -455,9 +437,17 @@ static esp_err_t call_claude_api(const assistant_config_t *cfg,
     esp_http_client_set_header(client, "x-api-key",           cfg->api_key);
     esp_http_client_set_header(client, "anthropic-version",   "2023-06-01");
     esp_http_client_set_header(client, "content-type",        "application/json");
-    esp_http_client_set_post_field(client, body, (int)strlen(body));
+    esp_err_t post_err = esp_http_client_set_post_field(client, body,
+                                                         (int)body_len);
+    if (post_err != ESP_OK) {
+        free(body);
+        esp_http_client_cleanup(client);
+        ESP_LOGE(TAG, "Failed to set assistant request body");
+        return post_err;
+    }
 
     esp_err_t err = esp_http_client_perform(client);
+    free(body);
     int status = esp_http_client_get_status_code(client);
     esp_http_client_cleanup(client);
 

--- a/components/apps_builtin/assistant/tests/test_assistant_request.c
+++ b/components/apps_builtin/assistant/tests/test_assistant_request.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) ThistleOS contributors
+
+#include "assistant_request.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define HISTORY_COUNT 6U
+#define MAX_MESSAGE_TEXT 511U
+
+static void fill_hostile_maximum(char *text, size_t length)
+{
+    static const char pattern[] = {'A', '"', '\\', '\n', '\r', '\t', '\x01'};
+    for (size_t index = 0; index < length; index++) {
+        text[index] = pattern[index % sizeof(pattern)];
+    }
+    text[length] = '\0';
+}
+
+static void test_maximum_history_is_safely_serialized(void)
+{
+    char content[MAX_MESSAGE_TEXT + 1U];
+    char system_prompt[256];
+    assistant_request_message_t history[HISTORY_COUNT];
+    fill_hostile_maximum(content, MAX_MESSAGE_TEXT);
+    fill_hostile_maximum(system_prompt, sizeof(system_prompt) - 1U);
+    for (size_t index = 0; index < HISTORY_COUNT; index++) {
+        history[index].role = index % 2U == 0 ? "user" : "assistant";
+        history[index].content = content;
+    }
+
+    size_t length = 0;
+    char *body = assistant_request_build(
+        "model-with-\"quote", system_prompt, history, HISTORY_COUNT,
+        content, &length);
+    assert(body != NULL);
+    assert(length == strlen(body));
+    assert(length > 2048U);
+    assert(strstr(body, "\\\"") != NULL);
+    assert(strstr(body, "\\\\") != NULL);
+    assert(strstr(body, "\\u0001") != NULL);
+    assert(strcmp(body + length - 3U, "}]}") == 0);
+    free(body);
+}
+
+static void test_invalid_inputs_fail_closed(void)
+{
+    size_t length = 123U;
+    assert(assistant_request_build(NULL, "system", NULL, 0, "message",
+                                   &length) == NULL);
+    assert(length == 0U);
+    assert(assistant_request_build("model", "system", NULL, 1, "message",
+                                   &length) == NULL);
+    assert(assistant_request_build("model", "system", NULL, 0, "message",
+                                   NULL) == NULL);
+}
+
+int main(void)
+{
+    test_maximum_history_is_safely_serialized();
+    test_invalid_inputs_fail_closed();
+    return 0;
+}

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -54,6 +54,7 @@ set(THISTLE_SRCS
     ${THISTLE_DIR}/components/apps_builtin/appstore/appstore_app.c
     ${THISTLE_DIR}/components/apps_builtin/appstore/appstore_ui.c
     ${THISTLE_DIR}/components/apps_builtin/assistant/assistant_app.c
+    ${THISTLE_DIR}/components/apps_builtin/assistant/assistant_request.c
     ${THISTLE_DIR}/components/apps_builtin/assistant/assistant_ui.c
     ${THISTLE_DIR}/components/apps_builtin/wifiscanner/wifiscanner_app.c
     ${THISTLE_DIR}/components/apps_builtin/wifiscanner/wifiscanner_ui.c


### PR DESCRIPTION
## What changed

- removes the fixed 2 KiB stack request and unchecked pointer arithmetic
- serializes through a two-pass checked writer that measures the fully escaped JSON first
- allocates exactly once on the heap and preserves all six context messages without truncation
- escapes model, system prompt, history, and current message as proper JSON strings
- refuses to initialize or perform HTTP if measurement, allocation, serialization, or post-field setup fails
- frees request storage on every path before response handling
- compiles the shared builder into firmware and simulator targets

## Validation

- maximum-length six-message source-to-sink regression: passed under ASan and UBSan
- malformed/null input fail-closed regression: passed
- full Rust host suite: 1,300 passed
- Rust checks passed for `esp32`, `esp32s2`, `esp32s3`, `esp32c3`, `esp32c6`, and `esp32h2`
- `git diff --check`: passed

The full ESP-IDF firmware, recovery, and simulator jobs remain required CI gates.

Resolves #64.
