### PR TITLE
Secure signing-key generation and ignore private keys

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,11 @@ jobs:
             -o /tmp/test_assistant_request
           /tmp/test_assistant_request
 
+      - name: Test secure signing-key generation
+        run: |
+          python3 -m pip install -r tools/requirements.txt
+          python3 tools/test_sign.py
+
   simulator-boot:
     name: Simulator Boot Test
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ managed_components/
 .cache/
 
 # Signing keys (NEVER commit private keys)
+private.key
 *_private.key
 tools/*_private.key
 

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,1 +1,2 @@
+cryptography>=42.0.0
 pynacl>=1.6.2

--- a/tools/sign.py
+++ b/tools/sign.py
@@ -2,6 +2,8 @@
 """ThistleOS Ed25519 signing tool for apps, drivers, and firmware."""
 
 import argparse
+import os
+from pathlib import Path
 import sys
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
@@ -11,19 +13,51 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
 from cryptography.exceptions import InvalidSignature
 
 
+PRIVATE_KEY_PATH = Path("private.key")
+PUBLIC_KEY_PATH = Path("public.key")
+
+
+def _require_absent(path):
+    """Reject files, directories, and symlinks before generating key material."""
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return
+    raise FileExistsError(f"refusing to overwrite existing path: {path}")
+
+
+def _write_new_file(path, data, mode):
+    """Create a new regular file without following or replacing existing paths."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags, mode)
+    try:
+        # os.open applies the process umask. Force the intended final mode on
+        # the already-open descriptor before writing any sensitive bytes.
+        os.fchmod(descriptor, mode)
+        with os.fdopen(descriptor, "wb", closefd=True) as output:
+            descriptor = -1
+            output.write(data)
+            output.flush()
+            os.fsync(output.fileno())
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
 def cmd_keygen(args):
+    _require_absent(PRIVATE_KEY_PATH)
+    _require_absent(PUBLIC_KEY_PATH)
+
     private_key = Ed25519PrivateKey.generate()
     private_bytes = private_key.private_bytes_raw()
     public_bytes = private_key.public_key().public_bytes_raw()
 
-    with open("private.key", "wb") as f:
-        f.write(private_bytes)
+    _write_new_file(PRIVATE_KEY_PATH, private_bytes, 0o600)
+    _write_new_file(PUBLIC_KEY_PATH, public_bytes, 0o644)
 
-    with open("public.key", "wb") as f:
-        f.write(public_bytes)
-
-    print(f"Private key written to: private.key")
-    print(f"Public key written to:  public.key")
+    print("Private key written to: private.key")
+    print("Public key written to:  public.key")
     print(f"Public key (hex): {public_bytes.hex()}")
 
 
@@ -86,12 +120,16 @@ def main():
 
     args = parser.parse_args()
 
-    if args.command == "keygen":
-        cmd_keygen(args)
-    elif args.command == "sign":
-        cmd_sign(args)
-    elif args.command == "verify":
-        cmd_verify(args)
+    try:
+        if args.command == "keygen":
+            cmd_keygen(args)
+        elif args.command == "sign":
+            cmd_sign(args)
+        elif args.command == "verify":
+            cmd_verify(args)
+    except OSError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tools/test_sign.py
+++ b/tools/test_sign.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Security regression tests for tools/sign.py key generation."""
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import unittest
+
+import sign
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+class KeyGenerationSecurityTests(unittest.TestCase):
+    def run_in_temporary_directory(self, callback):
+        original_directory = Path.cwd()
+        with tempfile.TemporaryDirectory() as directory:
+            os.chdir(directory)
+            try:
+                callback(Path(directory))
+            finally:
+                os.chdir(original_directory)
+
+    def test_keygen_forces_private_key_mode_under_permissive_umask(self):
+        def exercise(directory):
+            old_umask = os.umask(0)
+            try:
+                sign.cmd_keygen(None)
+            finally:
+                os.umask(old_umask)
+
+            private_key = directory / "private.key"
+            public_key = directory / "public.key"
+            self.assertEqual(private_key.stat().st_size, 32)
+            self.assertEqual(public_key.stat().st_size, 32)
+            self.assertEqual(stat.S_IMODE(private_key.stat().st_mode), 0o600)
+
+        self.run_in_temporary_directory(exercise)
+
+    def test_keygen_refuses_existing_private_key_without_modifying_it(self):
+        def exercise(directory):
+            private_key = directory / "private.key"
+            private_key.write_bytes(b"existing-secret")
+            private_key.chmod(0o644)
+
+            with self.assertRaises(FileExistsError):
+                sign.cmd_keygen(None)
+
+            self.assertEqual(private_key.read_bytes(), b"existing-secret")
+            self.assertFalse((directory / "public.key").exists())
+
+        self.run_in_temporary_directory(exercise)
+
+    def test_keygen_refuses_private_key_symlink_without_touching_target(self):
+        def exercise(directory):
+            victim = directory / "victim"
+            victim.write_bytes(b"do-not-overwrite")
+            (directory / "private.key").symlink_to(victim)
+
+            with self.assertRaises(FileExistsError):
+                sign.cmd_keygen(None)
+
+            self.assertEqual(victim.read_bytes(), b"do-not-overwrite")
+            self.assertFalse((directory / "public.key").exists())
+
+        self.run_in_temporary_directory(exercise)
+
+    def test_keygen_rejects_existing_public_path_before_private_key_sink(self):
+        def exercise(directory):
+            (directory / "public.key").write_bytes(b"existing-public-key")
+
+            with self.assertRaises(FileExistsError):
+                sign.cmd_keygen(None)
+
+            self.assertFalse((directory / "private.key").exists())
+
+        self.run_in_temporary_directory(exercise)
+
+    def test_generated_private_key_name_is_ignored(self):
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", "private.key"],
+            cwd=REPOSITORY_ROOT,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- create private.key exclusively without following or replacing existing paths
- force owner-only 0600 permissions before writing secret bytes, independent of umask
- sync key data before close and reject existing private or public output paths before generation
- ignore the generated private.key basename throughout the repository
- declare the cryptography dependency and run focused key-generation security tests in CI

## Validation

- 5 focused signing-key security tests passed
- Python syntax compilation passed
- git diff --check passed
- full repository and device checks are delegated to the required PR matrix

Closes #68