### PR TITLE
Keep OTA images rollback-eligible until boot health

### DIFF
--- a/components/kernel/include/thistle/ota.h
+++ b/components/kernel/include/thistle/ota.h
@@ -33,7 +33,8 @@ const char *ota_get_current_version(void);
 /* Get the currently running partition label */
 const char *ota_get_running_partition(void);
 
-/* Mark the current firmware as valid (prevents rollback) */
+/* Mark a pending current firmware as valid after the healthy-boot milestone.
+ * Idempotent: once confirmed, later calls do not invoke the OTA API again. */
 esp_err_t ota_mark_valid(void);
 
 /* Rollback to previous firmware */

--- a/components/kernel_rs/src/ota.rs
+++ b/components/kernel_rs/src/ota.rs
@@ -7,12 +7,14 @@
 
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
+use std::sync::Mutex;
 
 // ---------------------------------------------------------------------------
 // ESP-IDF error codes
 // ---------------------------------------------------------------------------
 
 const ESP_OK: i32 = 0x000;
+const ESP_FAIL: i32 = -1;
 const ESP_ERR_NO_MEM: i32 = 0x101;
 const ESP_ERR_NOT_FOUND: i32 = 0x105;
 const ESP_ERR_NOT_SUPPORTED: i32 = 0x106;
@@ -45,9 +47,8 @@ const ESP_LOG_ERROR: i32 = 1;
 /// ESP_OTA_IMG_PENDING_VERIFY state value from esp_ota_ops.h
 ///
 /// Replaces the C `esp_ota_img_pending_verify()` helper shim in kernel_shims.c.
-/// The constant value 0x107 matches ESP_OTA_IMG_PENDING_VERIFY in ESP-IDF v5.x.
-#[cfg(target_os = "espidf")]
-const ESP_OTA_IMG_PENDING_VERIFY: u32 = 0x107;
+/// ESP-IDF defines this enum value in `esp_flash_partitions.h` as 0x1.
+const ESP_OTA_IMG_PENDING_VERIFY: u32 = 0x1;
 
 #[cfg(target_os = "espidf")]
 extern "C" {
@@ -67,6 +68,41 @@ extern "C" {
 // Progress callback type — matches C typedef `void (*ota_progress_cb_t)(uint32_t written, uint32_t total, void *user_data)`
 pub type OtaProgressCb = unsafe extern "C" fn(written: u32, total: u32, user_data: *mut c_void);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BootValidationState {
+    NotPending,
+    Pending,
+    Validated,
+}
+
+impl BootValidationState {
+    fn observe_partition(&mut self, pending: bool) {
+        *self = if pending {
+            Self::Pending
+        } else {
+            Self::NotPending
+        };
+    }
+
+    fn mark_valid_once_with<F>(&mut self, mark_valid: F) -> i32
+    where
+        F: FnOnce() -> i32,
+    {
+        if *self != Self::Pending {
+            return ESP_OK;
+        }
+
+        let result = mark_valid();
+        if result == ESP_OK {
+            *self = Self::Validated;
+        }
+        result
+    }
+}
+
+static BOOT_VALIDATION_STATE: Mutex<BootValidationState> =
+    Mutex::new(BootValidationState::NotPending);
+
 /// OTA images are production artifacts, so only an explicit verifier success
 /// may cross the firmware trust boundary. Preserve the verifier's exact error
 /// for diagnostics instead of treating non-CRC failures as success.
@@ -82,16 +118,18 @@ fn require_valid_ota_signature(signature_result: i32) -> Result<(), i32> {
 // FFI exports
 // ---------------------------------------------------------------------------
 
-/// Initialise the OTA subsystem. Confirms the current OTA partition if it is
-/// in PENDING_VERIFY state.
+/// Initialise the OTA subsystem and remember whether the running partition is
+/// pending verification. Confirmation is deliberately deferred until the
+/// explicit healthy-boot milestone calls `ota_mark_valid()`.
 ///
 /// # Safety
 /// May be called from C.
 #[no_mangle]
 pub extern "C" fn ota_init() -> i32 {
+    let mut pending = false;
+
     #[cfg(target_os = "espidf")]
     unsafe {
-        use std::os::raw::c_void;
         let running = esp_ota_get_running_partition();
         if !running.is_null() {
             esp_log_write(
@@ -99,19 +137,24 @@ pub extern "C" fn ota_init() -> i32 {
                 TAG.as_ptr(),
                 b"Running OTA partition initialised\0".as_ptr(),
             );
-        }
 
-        let mut state: u32 = 0;
-        if esp_ota_get_state_partition(running, &mut state) == ESP_OK {
-            if state == ESP_OTA_IMG_PENDING_VERIFY {
+            let mut state: u32 = 0;
+            if esp_ota_get_state_partition(running, &mut state) == ESP_OK
+                && state == ESP_OTA_IMG_PENDING_VERIFY
+            {
+                pending = true;
                 esp_log_write(
                     ESP_LOG_INFO,
                     TAG.as_ptr(),
-                    b"Confirming OTA update (marking valid)\0".as_ptr(),
+                    b"OTA update awaiting healthy-boot confirmation\0".as_ptr(),
                 );
-                esp_ota_mark_app_valid_cancel_rollback();
             }
         }
+    }
+
+    match BOOT_VALIDATION_STATE.lock() {
+        Ok(mut state) => state.observe_partition(pending),
+        Err(_) => return ESP_FAIL,
     }
 
     unsafe {
@@ -342,8 +385,15 @@ pub extern "C" fn ota_get_running_partition() -> *const c_char {
 #[no_mangle]
 pub extern "C" fn ota_mark_valid() -> i32 {
     #[cfg(target_os = "espidf")]
-    unsafe {
-        return esp_ota_mark_app_valid_cancel_rollback();
+    {
+        return match BOOT_VALIDATION_STATE.lock() {
+            Ok(mut state) => {
+                state.mark_valid_once_with(|| unsafe {
+                    esp_ota_mark_app_valid_cancel_rollback()
+                })
+            }
+            Err(_) => ESP_FAIL,
+        };
     }
     #[cfg(not(target_os = "espidf"))]
     ESP_OK
@@ -396,6 +446,51 @@ mod tests {
         ] {
             assert_eq!(require_valid_ota_signature(error), Err(error));
         }
+    }
+
+    #[test]
+    fn test_pending_image_is_not_marked_before_health_milestone() {
+        let mut state = BootValidationState::NotPending;
+        let mark_calls = std::cell::Cell::new(0);
+
+        state.observe_partition(true);
+
+        assert_eq!(state, BootValidationState::Pending);
+        assert_eq!(mark_calls.get(), 0);
+    }
+
+    #[test]
+    fn test_pending_verify_value_matches_esp_idf_abi() {
+        assert_eq!(ESP_OTA_IMG_PENDING_VERIFY, 0x1);
+    }
+
+    #[test]
+    fn test_healthy_boot_marks_pending_image_exactly_once() {
+        let mut state = BootValidationState::NotPending;
+        let mark_calls = std::cell::Cell::new(0);
+        state.observe_partition(true);
+
+        for _ in 0..2 {
+            assert_eq!(
+                state.mark_valid_once_with(|| {
+                    mark_calls.set(mark_calls.get() + 1);
+                    ESP_OK
+                }),
+                ESP_OK
+            );
+        }
+
+        assert_eq!(state, BootValidationState::Validated);
+        assert_eq!(mark_calls.get(), 1);
+    }
+
+    #[test]
+    fn test_failed_confirmation_remains_pending_for_retry() {
+        let mut state = BootValidationState::NotPending;
+        state.observe_partition(true);
+
+        assert_eq!(state.mark_valid_once_with(|| ESP_FAIL), ESP_FAIL);
+        assert_eq!(state, BootValidationState::Pending);
     }
 
     // -----------------------------------------------------------------------

--- a/main/main.c
+++ b/main/main.c
@@ -223,7 +223,12 @@ void app_main(void)
         tk_register_input_callbacks();
 
         /* Launch the thistle-tk native launcher */
-        app_manager_launch("com.thistle.tk_launcher");
+        ret = app_manager_launch("com.thistle.tk_launcher");
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to launch thistle-tk launcher: %s",
+                     esp_err_to_name(ret));
+            return;
+        }
 
         /* Drive the display server for e-paper.
          * E-paper refresh is slow so we check every 100 ms; the WM
@@ -237,19 +242,41 @@ void app_main(void)
                                            16384, NULL, 5, NULL);
         if (task_ret != pdPASS) {
             ESP_LOGE(TAG, "tk_render: xTaskCreate failed (%d)", task_ret);
+            return;
         }
     } else {
-        app_manager_launch("com.thistle.launcher");
+        ret = app_manager_launch("com.thistle.launcher");
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to launch LVGL launcher: %s",
+                     esp_err_to_name(ret));
+            return;
+        }
 
         /* Start LVGL render loop AFTER all UI objects are created.
          * This prevents race conditions with e-paper's slow flush. */
-        ui_manager_start();
+        ret = ui_manager_start();
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to start LVGL render loop: %s",
+                     esp_err_to_name(ret));
+            return;
+        }
     }
 
     /* Check for SD card firmware update */
     if (ota_sd_update_available()) {
         ESP_LOGI(TAG, "Firmware update detected on SD card!");
         toast_show("Update available! Settings > About to install", TOAST_INFO, 5000);
+    }
+
+    /* Keep a newly flashed image rollback-eligible until all required boot
+     * services have initialized and remained alive through a short soak. */
+    ESP_LOGI(TAG, "Boot health milestone reached; soaking before OTA confirmation");
+    vTaskDelay(pdMS_TO_TICKS(5000));
+    ret = ota_mark_valid();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to confirm healthy OTA image: %s",
+                 esp_err_to_name(ret));
+        return;
     }
 
     ESP_LOGI(TAG, "ThistleOS ready");

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -46,6 +46,10 @@ CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096
 # Watchdog
 CONFIG_ESP_TASK_WDT_TIMEOUT_S=30
 
+# Keep newly installed OTA images rollback-eligible until app_main confirms
+# the post-initialization health milestone.
+CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
+
 # LVGL fonts (enable sizes used by ThistleOS UI)
 CONFIG_LV_FONT_MONTSERRAT_14=y
 CONFIG_LV_FONT_MONTSERRAT_18=y


### PR DESCRIPTION
## Summary

- stop confirming PENDING_VERIFY images during ota_init
- enable ESP-IDF bootloader rollback support and correct the pending-state ABI value from 0x107 to 0x1
- record pending state and confirm it idempotently only after the explicit boot-health milestone
- require successful kernel, display, window-manager, launcher, and render-loop startup
- add a five-second stability soak before confirmation
- leave failed confirmation pending so the device remains rollback-eligible
- add mocked confirmation tests for pre-milestone failure, exactly-once success, retry, and ABI state value

## Validation

- 10 focused OTA tests passed
- 1,304 full Rust kernel tests passed
- cargo +esp check passed
- full ESP-IDF ESP32-S3 firmware and bootloader build passed
- final firmware image has 14 percent free in the smallest app partition
- git diff --check passed

Closes #38