### PR TITLE
Bind release artifacts to a trusted successful CI run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,45 +24,74 @@ jobs:
           fetch-depth: 0
 
       - name: Validate tag
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
+          set -euo pipefail
+          python3 tools/validate_release.py tag "$RELEASE_TAG"
+          git check-ref-format "refs/tags/$RELEASE_TAG"
           git fetch --tags
-          git rev-parse "${{ inputs.tag }}^{}" >/dev/null
+          tag_commit="$(git rev-parse --verify "$RELEASE_TAG^{commit}")"
+          echo "RELEASE_TAG_COMMIT=$tag_commit" >> "$GITHUB_ENV"
+
+      - name: Validate CI artifact provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ inputs.run_id }}
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "ERROR: run_id must be numeric" >&2
+            exit 1
+          fi
+          metadata="$RUNNER_TEMP/release-source-run.json"
+          gh api \
+            "repos/$EXPECTED_REPOSITORY/actions/runs/$SOURCE_RUN_ID" \
+            > "$metadata"
+          python3 tools/validate_release.py run "$metadata" \
+            --repository "$EXPECTED_REPOSITORY" \
+            --commit "$RELEASE_TAG_COMMIT"
 
       - name: Download CI artifacts
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          gh run download "${{ inputs.run_id }}" --dir release-artifacts
-
-      - name: Stage versioned assets
+          SOURCE_RUN_ID: ${{ inputs.run_id }}
         run: |
           set -euo pipefail
-          tag="${{ inputs.tag }}"
+          gh run download "$SOURCE_RUN_ID" --dir release-artifacts
+
+      - name: Stage versioned assets
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
           mkdir -p dist
-          cp release-artifacts/thistle-os-firmware/thistle_os.bin "dist/thistle_os-${tag}.bin"
-          cp release-artifacts/thistle-os-firmware/thistle_os.bin.sig "dist/thistle_os-${tag}.bin.sig"
-          cp release-artifacts/thistle-os-firmware/thistle_os.bin.pub "dist/thistle_os-${tag}.bin.pub"
-          cp release-artifacts/thistle-recovery/thistle-recovery "dist/thistle-recovery-${tag}"
+          cp release-artifacts/thistle-os-firmware/thistle_os.bin "dist/thistle_os-${RELEASE_TAG}.bin"
+          cp release-artifacts/thistle-os-firmware/thistle_os.bin.sig "dist/thistle_os-${RELEASE_TAG}.bin.sig"
+          cp release-artifacts/thistle-os-firmware/thistle_os.bin.pub "dist/thistle_os-${RELEASE_TAG}.bin.pub"
+          cp release-artifacts/thistle-recovery/thistle-recovery "dist/thistle-recovery-${RELEASE_TAG}"
           cd dist
           sha256sum * > SHA256SUMS
 
       - name: Publish release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          tag="${{ inputs.tag }}"
           notes="$(mktemp)"
-          awk -v tag="$tag" '
+          awk -v tag="$RELEASE_TAG" '
             $0 ~ "^## " tag "($| - )" { capture=1; print; next }
             capture && /^## / { exit }
             capture { print }
           ' CHANGELOG.md > "$notes"
           if [ ! -s "$notes" ]; then
-            printf "Release %s\n" "$tag" > "$notes"
+            printf "Release %s\n" "$RELEASE_TAG" > "$notes"
           fi
-          if gh release view "$tag" >/dev/null 2>&1; then
-            gh release upload "$tag" dist/* --clobber
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" dist/* --clobber
           else
-            gh release create "$tag" dist/* --title "ThistleOS ${tag}" --notes-file "$notes"
+            gh release create "$RELEASE_TAG" dist/* \
+              --title "ThistleOS ${RELEASE_TAG}" --notes-file "$notes"
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,9 @@ jobs:
           python3 -m pip install -r tools/requirements.txt
           python3 tools/test_sign.py
 
+      - name: Test release input and provenance validation
+        run: python3 tools/test_validate_release.py
+
   simulator-boot:
     name: Simulator Boot Test
     runs-on: ubuntu-latest

--- a/tools/test_validate_release.py
+++ b/tools/test_validate_release.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Regression tests for release input and artifact provenance validation."""
+
+import copy
+from pathlib import Path
+import unittest
+
+import validate_release
+
+
+GOOD_SHA = "a" * 40
+GOOD_RUN = {
+    "id": 12345,
+    "html_url": "https://github.com/wan0net/thistle-os/actions/runs/12345",
+    "name": "ThistleOS CI",
+    "path": ".github/workflows/build.yml",
+    "event": "push",
+    "status": "completed",
+    "conclusion": "success",
+    "head_branch": "main",
+    "head_sha": GOOD_SHA,
+    "repository": {"full_name": "wan0net/thistle-os"},
+    "head_repository": {"full_name": "wan0net/thistle-os"},
+}
+
+
+class ReleaseValidationTests(unittest.TestCase):
+    def test_safe_release_tags_are_accepted(self):
+        for tag in ["v0.5.1", "v1.0.0-rc.1", "v12.34.56-beta"]:
+            self.assertEqual(validate_release.validate_tag(tag), tag)
+
+    def test_shell_and_ref_injection_tags_are_rejected(self):
+        for tag in [
+            "v0.5.1; id",
+            "v0.5.1$(id)",
+            "v0.5.1`id`",
+            "--help",
+            "refs/heads/main",
+            "v01.2.3",
+        ]:
+            with self.subTest(tag=tag), self.assertRaises(validate_release.ValidationError):
+                validate_release.validate_tag(tag)
+
+    def test_matching_successful_trusted_run_is_accepted(self):
+        provenance = validate_release.validate_run(
+            GOOD_RUN, "wan0net/thistle-os", GOOD_SHA
+        )
+        self.assertEqual(provenance["run_id"], 12345)
+        self.assertEqual(provenance["commit"], GOOD_SHA)
+
+    def test_failed_and_different_commit_runs_are_rejected(self):
+        for field, value in [
+            ("conclusion", "failure"),
+            ("status", "in_progress"),
+            ("head_sha", "b" * 40),
+        ]:
+            metadata = copy.deepcopy(GOOD_RUN)
+            metadata[field] = value
+            with self.subTest(field=field), self.assertRaises(validate_release.ValidationError):
+                validate_release.validate_run(
+                    metadata, "wan0net/thistle-os", GOOD_SHA
+                )
+
+    def test_untrusted_workflow_event_ref_and_repository_are_rejected(self):
+        cases = [
+            ("path", ".github/workflows/tests.yml"),
+            ("event", "pull_request"),
+            ("head_branch", "feature"),
+            ("repository", {"full_name": "attacker/fork"}),
+            ("head_repository", {"full_name": "attacker/fork"}),
+        ]
+        for field, value in cases:
+            metadata = copy.deepcopy(GOOD_RUN)
+            metadata[field] = value
+            with self.subTest(field=field), self.assertRaises(validate_release.ValidationError):
+                validate_release.validate_run(
+                    metadata, "wan0net/thistle-os", GOOD_SHA
+                )
+
+    def test_workflow_does_not_render_inputs_into_shell_source(self):
+        workflow = (
+            Path(__file__).resolve().parents[1] / ".github/workflows/release.yml"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn('tag="${{ inputs.tag }}"', workflow)
+        self.assertNotIn('gh run download "${{ inputs.run_id }}"', workflow)
+        self.assertIn("RELEASE_TAG: ${{ inputs.tag }}", workflow)
+        self.assertIn("SOURCE_RUN_ID: ${{ inputs.run_id }}", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate_release.py
+++ b/tools/validate_release.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Validate release tags and GitHub Actions artifact provenance."""
+
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+
+
+RELEASE_TAG = re.compile(
+    r"^v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+    r"(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$"
+)
+COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+class ValidationError(ValueError):
+    pass
+
+
+def validate_tag(tag):
+    if not RELEASE_TAG.fullmatch(tag):
+        raise ValidationError(
+            "release tag must use vMAJOR.MINOR.PATCH with an optional safe prerelease suffix"
+        )
+    return tag
+
+
+def validate_run(metadata, expected_repository, expected_sha):
+    if not COMMIT_SHA.fullmatch(expected_sha):
+        raise ValidationError("expected tag commit is not a full lowercase commit SHA")
+
+    expected = {
+        "name": "ThistleOS CI",
+        "path": ".github/workflows/build.yml",
+        "event": "push",
+        "status": "completed",
+        "conclusion": "success",
+        "head_branch": "main",
+        "head_sha": expected_sha,
+    }
+    for field, value in expected.items():
+        if metadata.get(field) != value:
+            raise ValidationError(
+                f"run {field} mismatch: expected {value!r}, got {metadata.get(field)!r}"
+            )
+
+    repository = (metadata.get("repository") or {}).get("full_name")
+    head_repository = (metadata.get("head_repository") or {}).get("full_name")
+    if repository != expected_repository:
+        raise ValidationError(
+            f"run repository mismatch: expected {expected_repository!r}, got {repository!r}"
+        )
+    if head_repository != expected_repository:
+        raise ValidationError(
+            "run head repository is not the trusted release repository"
+        )
+
+    return {
+        "run_id": metadata.get("id"),
+        "run_url": metadata.get("html_url"),
+        "repository": repository,
+        "workflow": metadata["path"],
+        "event": metadata["event"],
+        "branch": metadata["head_branch"],
+        "commit": metadata["head_sha"],
+        "conclusion": metadata["conclusion"],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    tag_parser = subparsers.add_parser("tag")
+    tag_parser.add_argument("tag")
+
+    run_parser = subparsers.add_parser("run")
+    run_parser.add_argument("metadata", type=Path)
+    run_parser.add_argument("--repository", required=True)
+    run_parser.add_argument("--commit", required=True)
+
+    args = parser.parse_args()
+    try:
+        if args.command == "tag":
+            print(f"Validated release tag: {validate_tag(args.tag)}")
+        else:
+            metadata = json.loads(args.metadata.read_text(encoding="utf-8"))
+            provenance = validate_run(metadata, args.repository, args.commit)
+            print("Validated artifact provenance:")
+            print(json.dumps(provenance, sort_keys=True))
+    except (OSError, json.JSONDecodeError, ValidationError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- validate release tags with a strict semantic-version allowlist and git ref checks
- pass operator inputs only through environment variables, never by rendering them into shell source
- fetch source-run metadata before artifact download
- require the canonical repository and head repository, ThistleOS CI workflow path and name, completed successful push event, main branch, and exact tag commit SHA
- reject nonnumeric run IDs, failed or incomplete runs, pull-request or fork runs, wrong workflows and branches, and different commits
- log the validated provenance record before download
- add focused regression tests and run them in CI

## Validation

- 6 release input and provenance tests passed
- safe and hostile tag cases covered
- matching, failed, different-commit, wrong-workflow, wrong-event, wrong-ref, and wrong-repository runs covered
- workflow source-to-shell regression assertions passed
- git diff --check passed

Closes #58
Closes #73