### PR TITLE
Make recovery bundle activation transactional

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,6 +84,12 @@ jobs:
       - name: Test release input and provenance validation
         run: python3 tools/test_validate_release.py
 
+      - name: Test transactional recovery bundle activation
+        run: |
+          rustc --edition=2021 --test recovery/src/bundle_transaction.rs \
+            -o /tmp/test_bundle_transaction
+          /tmp/test_bundle_transaction
+
   simulator-boot:
     name: Simulator Boot Test
     runs-on: ubuntu-latest

--- a/components/kernel/include/thistle/ota.h
+++ b/components/kernel/include/thistle/ota.h
@@ -37,5 +37,8 @@ const char *ota_get_running_partition(void);
  * Idempotent: once confirmed, later calls do not invoke the OTA API again. */
 esp_err_t ota_mark_valid(void);
 
+/* Remove the recovery bundle journal and backups after ota_mark_valid(). */
+esp_err_t ota_finalize_bundle_transaction(void);
+
 /* Rollback to previous firmware */
 esp_err_t ota_rollback(void);

--- a/components/kernel_rs/src/ota.rs
+++ b/components/kernel_rs/src/ota.rs
@@ -7,6 +7,7 @@
 
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
+use std::path::Path;
 use std::sync::Mutex;
 
 // ---------------------------------------------------------------------------
@@ -23,6 +24,8 @@ const ESP_ERR_INVALID_CRC: i32 = 0x109;
 
 const OTA_BUF_SIZE: usize = 4096;
 const OTA_SD_UPDATE_PATH: &str = "/sdcard/update/thistle_os.bin\0";
+const BUNDLE_TRANSACTION_PATH: &str = "/sdcard/.thistle-bundle-transaction";
+const BUNDLE_DOWNLOAD_PATH: &str = "/sdcard/.thistle-bundle-download";
 const MAX_OTA_SIZE: u64 = 16 * 1024 * 1024; // 16 MB
 
 static TAG: &[u8] = b"ota\0";
@@ -36,8 +39,8 @@ extern "C" {
     fn signing_verify_file(path: *const c_char) -> i32;
 }
 
-const ESP_LOG_INFO:  i32 = 3;
-const ESP_LOG_WARN:  i32 = 2;
+const ESP_LOG_INFO: i32 = 3;
+const ESP_LOG_WARN: i32 = 2;
 const ESP_LOG_ERROR: i32 = 1;
 
 // ---------------------------------------------------------------------------
@@ -228,11 +231,19 @@ pub unsafe extern "C" fn ota_apply_from_sd(
     };
 
     if file_size == 0 {
-        esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"Update file is empty\0".as_ptr());
+        esp_log_write(
+            ESP_LOG_ERROR,
+            TAG.as_ptr(),
+            b"Update file is empty\0".as_ptr(),
+        );
         return ESP_ERR_INVALID_SIZE;
     }
     if file_size > MAX_OTA_SIZE {
-        esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"OTA file too large\0".as_ptr());
+        esp_log_write(
+            ESP_LOG_ERROR,
+            TAG.as_ptr(),
+            b"OTA file too large\0".as_ptr(),
+        );
         return ESP_ERR_INVALID_SIZE;
     }
 
@@ -247,14 +258,23 @@ pub unsafe extern "C" fn ota_apply_from_sd(
     {
         let update_partition = esp_ota_get_next_update_partition(std::ptr::null());
         if update_partition.is_null() {
-            esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"No OTA partition available\0".as_ptr());
+            esp_log_write(
+                ESP_LOG_ERROR,
+                TAG.as_ptr(),
+                b"No OTA partition available\0".as_ptr(),
+            );
             return ESP_ERR_NOT_FOUND;
         }
 
         let mut ota_handle: u32 = 0;
         let ret = esp_ota_begin(update_partition, file_size as usize, &mut ota_handle);
         if ret != ESP_OK {
-            esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"esp_ota_begin failed: %d\0".as_ptr(), ret);
+            esp_log_write(
+                ESP_LOG_ERROR,
+                TAG.as_ptr(),
+                b"esp_ota_begin failed: %d\0".as_ptr(),
+                ret,
+            );
             return ret;
         }
 
@@ -263,7 +283,9 @@ pub unsafe extern "C" fn ota_apply_from_sd(
 
         loop {
             let to_read = OTA_BUF_SIZE.min((file_size - written as u64) as usize);
-            if to_read == 0 { break; }
+            if to_read == 0 {
+                break;
+            }
 
             let nread = match file.read(&mut buf[..to_read]) {
                 Ok(0) => break,
@@ -277,7 +299,12 @@ pub unsafe extern "C" fn ota_apply_from_sd(
 
             let ret = esp_ota_write(ota_handle, buf.as_ptr(), nread);
             if ret != ESP_OK {
-                esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"esp_ota_write failed: %d\0".as_ptr(), ret);
+                esp_log_write(
+                    ESP_LOG_ERROR,
+                    TAG.as_ptr(),
+                    b"esp_ota_write failed: %d\0".as_ptr(),
+                    ret,
+                );
                 esp_ota_abort(ota_handle);
                 return ret;
             }
@@ -291,7 +318,12 @@ pub unsafe extern "C" fn ota_apply_from_sd(
 
         let ret = esp_ota_end(ota_handle);
         if ret != ESP_OK {
-            esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"esp_ota_end failed: %d\0".as_ptr(), ret);
+            esp_log_write(
+                ESP_LOG_ERROR,
+                TAG.as_ptr(),
+                b"esp_ota_end failed: %d\0".as_ptr(),
+                ret,
+            );
             return ret;
         }
 
@@ -388,14 +420,32 @@ pub extern "C" fn ota_mark_valid() -> i32 {
     {
         return match BOOT_VALIDATION_STATE.lock() {
             Ok(mut state) => {
-                state.mark_valid_once_with(|| unsafe {
-                    esp_ota_mark_app_valid_cancel_rollback()
-                })
+                state.mark_valid_once_with(|| unsafe { esp_ota_mark_app_valid_cancel_rollback() })
             }
             Err(_) => ESP_FAIL,
         };
     }
     #[cfg(not(target_os = "espidf"))]
+    ESP_OK
+}
+
+fn finalize_bundle_transaction_at(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// Remove rollback files only after the matching OTA image is healthy and valid.
+/// Recovery can also finalize this journal on a later boot if SD cleanup fails.
+#[no_mangle]
+pub extern "C" fn ota_finalize_bundle_transaction() -> i32 {
+    for path in [BUNDLE_TRANSACTION_PATH, BUNDLE_DOWNLOAD_PATH] {
+        if finalize_bundle_transaction_at(Path::new(path)).is_err() {
+            return ESP_FAIL;
+        }
+    }
     ESP_OK
 }
 
@@ -501,7 +551,10 @@ mod tests {
     #[test]
     fn test_get_current_version_non_null() {
         let ptr = ota_get_current_version();
-        assert!(!ptr.is_null(), "ota_get_current_version() must not return NULL");
+        assert!(
+            !ptr.is_null(),
+            "ota_get_current_version() must not return NULL"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -526,7 +579,10 @@ mod tests {
         // In the test environment there is no SD card, so the update path
         // /sdcard/update/thistle_os.bin does not exist.
         let available = ota_sd_update_available();
-        assert!(!available, "ota_sd_update_available() must return false when no SD card");
+        assert!(
+            !available,
+            "ota_sd_update_available() must return false when no SD card"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -540,6 +596,19 @@ mod tests {
         assert_eq!(rc, ESP_OK, "ota_mark_valid() must return ESP_OK on host");
     }
 
+    #[test]
+    fn test_bundle_transaction_cleanup_is_idempotent() {
+        let root =
+            std::env::temp_dir().join(format!("thistle-ota-finalize-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("backup")).unwrap();
+        std::fs::write(root.join("journal"), b"transaction").unwrap();
+
+        finalize_bundle_transaction_at(&root).unwrap();
+        assert!(!root.exists());
+        finalize_bundle_transaction_at(&root).unwrap();
+    }
+
     // -----------------------------------------------------------------------
     // test_get_running_partition_non_null
     // ota_get_running_partition() returns "unknown" on host builds.
@@ -548,7 +617,10 @@ mod tests {
     #[test]
     fn test_get_running_partition_non_null() {
         let ptr = ota_get_running_partition();
-        assert!(!ptr.is_null(), "ota_get_running_partition() must not return NULL");
+        assert!(
+            !ptr.is_null(),
+            "ota_get_running_partition() must not return NULL"
+        );
         let s = unsafe { CStr::from_ptr(ptr).to_str().unwrap() };
         assert_eq!(s, "unknown", "partition must be \"unknown\" on host builds");
     }

--- a/main/main.c
+++ b/main/main.c
@@ -278,6 +278,13 @@ void app_main(void)
                  esp_err_to_name(ret));
         return;
     }
+    ret = ota_finalize_bundle_transaction();
+    if (ret != ESP_OK) {
+        /* The image is already valid. Recovery will safely retry finalization
+         * if the SD card was temporarily unavailable at this milestone. */
+        ESP_LOGW(TAG, "Could not finalize recovery bundle transaction: %s",
+                 esp_err_to_name(ret));
+    }
 
     ESP_LOGI(TAG, "ThistleOS ready");
 

--- a/recovery/src/bundle_transaction.rs
+++ b/recovery/src/bundle_transaction.rs
@@ -1,0 +1,637 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Power-loss-safe filesystem transaction used by Recovery bundle installs.
+
+use std::collections::HashSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Component, Path, PathBuf};
+
+pub const TRANSACTION_DIR: &str = ".thistle-bundle-transaction";
+const STAGE_DIR: &str = "stage";
+const BACKUP_DIR: &str = "backup";
+const JOURNAL_FILE: &str = "journal";
+const JOURNAL_TMP: &str = "journal.tmp";
+const JOURNAL_VERSION: &str = "THISTLE_BUNDLE_V1";
+const FILES_ACTIVE_MARKER: &str = "files-active";
+const FIRMWARE_WRITTEN_MARKER: &str = "firmware-written";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Phase {
+    Prepared,
+    FilesActive,
+    FirmwareWritten,
+}
+
+impl Phase {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Prepared => "prepared",
+            Self::FilesActive => "files_active",
+            Self::FirmwareWritten => "firmware_written",
+        }
+    }
+
+    fn parse(value: &str) -> io::Result<Self> {
+        match value {
+            "prepared" => Ok(Self::Prepared),
+            "files_active" => Ok(Self::FilesActive),
+            "firmware_written" => Ok(Self::FirmwareWritten),
+            _ => Err(invalid_data("unknown bundle transaction phase")),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecoveryAction {
+    None,
+    Rollback,
+    Finalize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Boundary {
+    StageFile(usize),
+    WritePreparedJournal,
+    BackupFile(usize),
+    ActivateFile(usize),
+    WriteFilesActiveJournal,
+    WriteFirmware,
+    WriteFirmwareJournal,
+    SelectBootPartition,
+}
+
+#[derive(Debug)]
+pub struct BundleFile {
+    relative_path: PathBuf,
+    contents: BundleContents,
+}
+
+#[derive(Debug)]
+enum BundleContents {
+    Bytes(Vec<u8>),
+    File(PathBuf),
+}
+
+impl BundleFile {
+    pub fn new(relative_path: impl Into<PathBuf>, data: Vec<u8>) -> io::Result<Self> {
+        let relative_path = relative_path.into();
+        validate_relative_path(&relative_path)?;
+        Ok(Self {
+            relative_path,
+            contents: BundleContents::Bytes(data),
+        })
+    }
+
+    pub fn from_file(
+        relative_path: impl Into<PathBuf>,
+        source_path: impl Into<PathBuf>,
+    ) -> io::Result<Self> {
+        let relative_path = relative_path.into();
+        validate_relative_path(&relative_path)?;
+        Ok(Self {
+            relative_path,
+            contents: BundleContents::File(source_path.into()),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct JournalEntry {
+    had_original: bool,
+    relative_path: PathBuf,
+}
+
+#[derive(Debug)]
+struct Journal {
+    phase: Phase,
+    entries: Vec<JournalEntry>,
+}
+
+pub fn transaction_exists(root: &Path) -> bool {
+    journal_path(root).exists()
+}
+
+pub fn recovery_action(
+    root: &Path,
+    ota_image_is_selected: bool,
+    ota_image_is_valid: bool,
+) -> io::Result<RecoveryAction> {
+    if !transaction_exists(root) {
+        return Ok(RecoveryAction::None);
+    }
+    let journal = read_journal(root)?;
+    if journal.phase == Phase::FirmwareWritten && ota_image_is_selected && ota_image_is_valid {
+        Ok(RecoveryAction::Finalize)
+    } else {
+        Ok(RecoveryAction::Rollback)
+    }
+}
+
+/// Install already-downloaded, already-verified files as one reversible generation.
+/// The successful path deliberately leaves the journal and backups in place until
+/// the new firmware confirms a healthy boot.
+pub fn install<F, S, B>(
+    root: &Path,
+    files: &[BundleFile],
+    mut write_firmware: F,
+    mut select_boot_partition: S,
+    mut boundary: B,
+) -> io::Result<()>
+where
+    F: FnMut() -> io::Result<()>,
+    S: FnMut() -> io::Result<()>,
+    B: FnMut(Boundary) -> io::Result<()>,
+{
+    if transaction_exists(root) {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "an unfinished bundle transaction already exists",
+        ));
+    }
+
+    let tx_root = transaction_root(root);
+    if tx_root.exists() {
+        fs::remove_dir_all(&tx_root)?;
+    }
+    fs::create_dir_all(tx_root.join(STAGE_DIR))?;
+    fs::create_dir_all(tx_root.join(BACKUP_DIR))?;
+
+    let mut entries = Vec::with_capacity(files.len());
+    let mut unique_paths = HashSet::new();
+    let prepare_result = (|| {
+        for (index, file) in files.iter().enumerate() {
+            if !unique_paths.insert(file.relative_path.clone()) {
+                return Err(invalid_input("duplicate bundle destination"));
+            }
+            boundary(Boundary::StageFile(index))?;
+            let staged = tx_root.join(STAGE_DIR).join(&file.relative_path);
+            stage_contents(&staged, &file.contents)?;
+            entries.push(JournalEntry {
+                had_original: root.join(&file.relative_path).exists(),
+                relative_path: file.relative_path.clone(),
+            });
+        }
+        boundary(Boundary::WritePreparedJournal)?;
+        write_journal(
+            root,
+            &Journal {
+                phase: Phase::Prepared,
+                entries,
+            },
+        )
+    })();
+
+    if let Err(error) = prepare_result {
+        let _ = fs::remove_dir_all(&tx_root);
+        return Err(error);
+    }
+
+    let operation_result = (|| {
+        let mut journal = read_journal(root)?;
+        for (index, entry) in journal.entries.iter().enumerate() {
+            let destination = root.join(&entry.relative_path);
+            let staged = tx_root.join(STAGE_DIR).join(&entry.relative_path);
+            let backup = tx_root.join(BACKUP_DIR).join(&entry.relative_path);
+
+            if entry.had_original {
+                boundary(Boundary::BackupFile(index))?;
+                ensure_parent(&backup)?;
+                fs::rename(&destination, &backup)?;
+            }
+
+            boundary(Boundary::ActivateFile(index))?;
+            ensure_parent(&destination)?;
+            fs::rename(&staged, &destination)?;
+        }
+
+        boundary(Boundary::WriteFilesActiveJournal)?;
+        journal.phase = Phase::FilesActive;
+        write_phase(root, journal.phase)?;
+
+        boundary(Boundary::WriteFirmware)?;
+        write_firmware()?;
+
+        boundary(Boundary::WriteFirmwareJournal)?;
+        journal.phase = Phase::FirmwareWritten;
+        write_phase(root, journal.phase)?;
+
+        boundary(Boundary::SelectBootPartition)?;
+        select_boot_partition()
+    })();
+
+    if let Err(error) = operation_result {
+        let rollback_error = rollback(root).err();
+        return match rollback_error {
+            Some(rollback_error) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("{error}; rollback also failed: {rollback_error}"),
+            )),
+            None => Err(error),
+        };
+    }
+
+    Ok(())
+}
+
+pub fn rollback(root: &Path) -> io::Result<()> {
+    if !transaction_exists(root) {
+        return Ok(());
+    }
+    let journal = read_journal(root)?;
+    let tx_root = transaction_root(root);
+
+    for entry in journal.entries.iter().rev() {
+        let destination = root.join(&entry.relative_path);
+        let staged = tx_root.join(STAGE_DIR).join(&entry.relative_path);
+        let backup = tx_root.join(BACKUP_DIR).join(&entry.relative_path);
+
+        if entry.had_original {
+            if backup.exists() {
+                remove_file_if_present(&destination)?;
+                ensure_parent(&destination)?;
+                fs::rename(&backup, &destination)?;
+            }
+        } else if !staged.exists() {
+            remove_file_if_present(&destination)?;
+        }
+    }
+
+    fs::remove_dir_all(tx_root)
+}
+
+pub fn finalize(root: &Path) -> io::Result<()> {
+    let tx_root = transaction_root(root);
+    if tx_root.exists() {
+        fs::remove_dir_all(tx_root)?;
+    }
+    Ok(())
+}
+
+fn transaction_root(root: &Path) -> PathBuf {
+    root.join(TRANSACTION_DIR)
+}
+
+fn journal_path(root: &Path) -> PathBuf {
+    transaction_root(root).join(JOURNAL_FILE)
+}
+
+fn write_journal(root: &Path, journal: &Journal) -> io::Result<()> {
+    if journal.phase != Phase::Prepared || journal_path(root).exists() {
+        return Err(invalid_input("the bundle journal may only be created once"));
+    }
+    let tx_root = transaction_root(root);
+    fs::create_dir_all(&tx_root)?;
+    let tmp = tx_root.join(JOURNAL_TMP);
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&tmp)?;
+    writeln!(file, "{JOURNAL_VERSION}")?;
+    writeln!(file, "phase={}", Phase::Prepared.as_str())?;
+    for entry in &journal.entries {
+        let path = entry
+            .relative_path
+            .to_str()
+            .ok_or_else(|| invalid_input("bundle path is not UTF-8"))?;
+        writeln!(file, "{}\t{}", u8::from(entry.had_original), path)?;
+    }
+    file.sync_all()?;
+    drop(file);
+    fs::rename(tmp, journal_path(root))?;
+    Ok(())
+}
+
+fn read_journal(root: &Path) -> io::Result<Journal> {
+    let contents = fs::read_to_string(journal_path(root))?;
+    let mut lines = contents.lines();
+    if lines.next() != Some(JOURNAL_VERSION) {
+        return Err(invalid_data("unsupported bundle transaction journal"));
+    }
+    let phase_line = lines
+        .next()
+        .and_then(|line| line.strip_prefix("phase="))
+        .ok_or_else(|| invalid_data("bundle transaction journal has no phase"))?;
+    if Phase::parse(phase_line)? != Phase::Prepared {
+        return Err(invalid_data("bundle journal must begin in prepared phase"));
+    }
+    let tx_root = transaction_root(root);
+    let phase = if tx_root.join(FIRMWARE_WRITTEN_MARKER).exists() {
+        Phase::FirmwareWritten
+    } else if tx_root.join(FILES_ACTIVE_MARKER).exists() {
+        Phase::FilesActive
+    } else {
+        Phase::Prepared
+    };
+    let mut entries = Vec::new();
+    let mut unique_paths = HashSet::new();
+    for line in lines {
+        let (existed, path) = line
+            .split_once('\t')
+            .ok_or_else(|| invalid_data("malformed bundle transaction entry"))?;
+        let relative_path = PathBuf::from(path);
+        validate_relative_path(&relative_path)?;
+        if !unique_paths.insert(relative_path.clone()) {
+            return Err(invalid_data("duplicate path in bundle transaction journal"));
+        }
+        entries.push(JournalEntry {
+            had_original: match existed {
+                "0" => false,
+                "1" => true,
+                _ => return Err(invalid_data("invalid original-file marker")),
+            },
+            relative_path,
+        });
+    }
+    if entries.is_empty() {
+        return Err(invalid_data("empty bundle transaction journal"));
+    }
+    Ok(Journal { phase, entries })
+}
+
+fn write_phase(root: &Path, phase: Phase) -> io::Result<()> {
+    let marker = match phase {
+        Phase::Prepared => return Ok(()),
+        Phase::FilesActive => FILES_ACTIVE_MARKER,
+        Phase::FirmwareWritten => FIRMWARE_WRITTEN_MARKER,
+    };
+    write_synced(
+        &transaction_root(root).join(marker),
+        phase.as_str().as_bytes(),
+    )
+}
+
+fn validate_relative_path(path: &Path) -> io::Result<()> {
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        return Err(invalid_input("bundle destination must be relative"));
+    }
+    for component in path.components() {
+        if !matches!(component, Component::Normal(_)) {
+            return Err(invalid_input(
+                "bundle destination contains unsafe components",
+            ));
+        }
+    }
+    let text = path
+        .to_str()
+        .ok_or_else(|| invalid_input("bundle destination is not UTF-8"))?;
+    if text.contains('\t') || text.contains('\n') || text.contains('\r') {
+        return Err(invalid_input(
+            "bundle destination contains control characters",
+        ));
+    }
+    Ok(())
+}
+
+fn write_synced(path: &Path, data: &[u8]) -> io::Result<()> {
+    ensure_parent(path)?;
+    let mut file = File::create(path)?;
+    file.write_all(data)?;
+    file.sync_all()
+}
+
+fn stage_contents(path: &Path, contents: &BundleContents) -> io::Result<()> {
+    match contents {
+        BundleContents::Bytes(data) => write_synced(path, data),
+        BundleContents::File(source) => {
+            ensure_parent(path)?;
+            fs::copy(source, path)?;
+            OpenOptions::new().write(true).open(path)?.sync_all()
+        }
+    }
+}
+
+fn ensure_parent(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    Ok(())
+}
+
+fn remove_file_if_present(path: &Path) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn invalid_input(message: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message)
+}
+
+fn invalid_data(message: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+
+    struct TestRoot(PathBuf);
+
+    impl TestRoot {
+        fn new() -> Self {
+            let id = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "thistle-bundle-transaction-{}-{id}",
+                std::process::id()
+            ));
+            let _ = fs::remove_dir_all(&path);
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TestRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn files() -> Vec<BundleFile> {
+        vec![
+            BundleFile::new("drivers/display.drv.elf", b"new-driver".to_vec()).unwrap(),
+            BundleFile::new("wm/default.wm.elf", b"new-wm".to_vec()).unwrap(),
+        ]
+    }
+
+    fn seed_originals(root: &Path) {
+        write_synced(&root.join("drivers/display.drv.elf"), b"old-driver").unwrap();
+    }
+
+    fn assert_original_generation(root: &Path) {
+        assert_eq!(
+            fs::read(root.join("drivers/display.drv.elf")).unwrap(),
+            b"old-driver"
+        );
+        assert!(!root.join("wm/default.wm.elf").exists());
+        assert!(!transaction_root(root).exists());
+    }
+
+    #[test]
+    fn success_orders_boot_selection_last_and_preserves_rollback_state() {
+        let root = TestRoot::new();
+        seed_originals(&root.0);
+        let events = RefCell::new(Vec::new());
+        install(
+            &root.0,
+            &files(),
+            || {
+                events.borrow_mut().push("firmware");
+                Ok(())
+            },
+            || {
+                events.borrow_mut().push("boot");
+                Ok(())
+            },
+            |_| Ok(()),
+        )
+        .unwrap();
+
+        assert_eq!(*events.borrow(), ["firmware", "boot"]);
+        assert_eq!(
+            fs::read(root.0.join("drivers/display.drv.elf")).unwrap(),
+            b"new-driver"
+        );
+        assert_eq!(
+            fs::read(root.0.join("wm/default.wm.elf")).unwrap(),
+            b"new-wm"
+        );
+        assert_eq!(
+            recovery_action(&root.0, true, false).unwrap(),
+            RecoveryAction::Rollback
+        );
+        assert_eq!(
+            recovery_action(&root.0, false, true).unwrap(),
+            RecoveryAction::Rollback
+        );
+        assert_eq!(
+            recovery_action(&root.0, true, true).unwrap(),
+            RecoveryAction::Finalize
+        );
+        finalize(&root.0).unwrap();
+        assert!(!transaction_exists(&root.0));
+    }
+
+    #[test]
+    fn every_activation_boundary_rolls_back_on_failure() {
+        let boundaries = [
+            Boundary::StageFile(0),
+            Boundary::StageFile(1),
+            Boundary::WritePreparedJournal,
+            Boundary::BackupFile(0),
+            Boundary::ActivateFile(0),
+            Boundary::ActivateFile(1),
+            Boundary::WriteFilesActiveJournal,
+            Boundary::WriteFirmware,
+            Boundary::WriteFirmwareJournal,
+            Boundary::SelectBootPartition,
+        ];
+
+        for failed_boundary in boundaries {
+            let root = TestRoot::new();
+            seed_originals(&root.0);
+            let result = install(
+                &root.0,
+                &files(),
+                || Ok(()),
+                || Ok(()),
+                |boundary| {
+                    if boundary == failed_boundary {
+                        Err(io::Error::new(io::ErrorKind::Other, "injected failure"))
+                    } else {
+                        Ok(())
+                    }
+                },
+            );
+            assert!(
+                result.is_err(),
+                "boundary {failed_boundary:?} unexpectedly succeeded"
+            );
+            assert_original_generation(&root.0);
+        }
+    }
+
+    #[test]
+    fn recovery_restores_a_power_loss_after_each_file_move() {
+        for stop_after in 0..=2 {
+            let root = TestRoot::new();
+            seed_originals(&root.0);
+            let tx_root = transaction_root(&root.0);
+            fs::create_dir_all(tx_root.join(STAGE_DIR)).unwrap();
+            fs::create_dir_all(tx_root.join(BACKUP_DIR)).unwrap();
+            let test_files = files();
+            let entries: Vec<_> = test_files
+                .iter()
+                .map(|file| {
+                    write_synced(
+                        &tx_root.join(STAGE_DIR).join(&file.relative_path),
+                        match &file.contents {
+                            BundleContents::Bytes(data) => data,
+                            BundleContents::File(_) => unreachable!(),
+                        },
+                    )
+                    .unwrap();
+                    JournalEntry {
+                        had_original: root.0.join(&file.relative_path).exists(),
+                        relative_path: file.relative_path.clone(),
+                    }
+                })
+                .collect();
+            write_journal(
+                &root.0,
+                &Journal {
+                    phase: Phase::Prepared,
+                    entries,
+                },
+            )
+            .unwrap();
+
+            for entry in read_journal(&root.0)
+                .unwrap()
+                .entries
+                .iter()
+                .take(stop_after)
+            {
+                let destination = root.0.join(&entry.relative_path);
+                let staged = tx_root.join(STAGE_DIR).join(&entry.relative_path);
+                let backup = tx_root.join(BACKUP_DIR).join(&entry.relative_path);
+                if entry.had_original {
+                    ensure_parent(&backup).unwrap();
+                    fs::rename(&destination, backup).unwrap();
+                }
+                ensure_parent(&destination).unwrap();
+                fs::rename(staged, destination).unwrap();
+            }
+
+            rollback(&root.0).unwrap();
+            assert_original_generation(&root.0);
+        }
+    }
+
+    #[test]
+    fn journal_rejects_path_traversal() {
+        assert!(BundleFile::new("../outside", vec![]).is_err());
+        assert!(BundleFile::new("/absolute", vec![]).is_err());
+    }
+
+    #[test]
+    fn file_backed_artifacts_are_copied_into_the_transaction_stage() {
+        let root = TestRoot::new();
+        let source = root.0.join("downloaded-driver");
+        write_synced(&source, b"verified-driver").unwrap();
+        let file = BundleFile::from_file("drivers/display.drv.elf", &source).unwrap();
+
+        install(&root.0, &[file], || Ok(()), || Ok(()), |_| Ok(())).unwrap();
+
+        assert_eq!(
+            fs::read(root.0.join("drivers/display.drv.elf")).unwrap(),
+            b"verified-driver"
+        );
+    }
+}

--- a/recovery/src/main.rs
+++ b/recovery/src/main.rs
@@ -22,6 +22,7 @@ use esp_idf_svc::wifi::{
 
 use log::*;
 
+mod bundle_transaction;
 mod catalog_path;
 mod recovery_ota;
 mod recovery_web;
@@ -56,6 +57,10 @@ fn main() -> anyhow::Result<()> {
         let mut st = recovery_web::STATE.lock().unwrap();
         st.chip = chip.to_string();
     }
+
+    // Resolve any filesystem generation left by a reset or OTA rollback before
+    // deciding whether ota_1 is safe to boot.
+    recovery_ota::recover_interrupted_bundle()?;
 
     // Step 1: Check if ota_1 has valid firmware
     info!("Checking ota_1 partition...");

--- a/recovery/src/recovery_ota.rs
+++ b/recovery/src/recovery_ota.rs
@@ -5,8 +5,11 @@ use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use esp_idf_svc::http::client::{Configuration as HttpConfig, EspHttpConnection};
 use esp_idf_sys::*;
 use log::*;
+use std::io;
+use std::path::Path;
 use std::sync::atomic::{AtomicU8, Ordering};
 
+use crate::bundle_transaction::{self, Boundary, BundleFile, RecoveryAction};
 use crate::catalog_path::{catalog_destination, validate_catalog_id};
 
 // ---------------------------------------------------------------------------
@@ -78,6 +81,7 @@ pub fn catalog_entry_arch_matches(obj: &str, chip: &str) -> bool {
 }
 
 const SD_FIRMWARE_PATH: &str = "/sdcard/update/thistle_os.bin";
+const BUNDLE_DOWNLOAD_DIR: &str = "/sdcard/.thistle-bundle-download";
 const MAX_FIRMWARE_SIZE: usize = 4 * 1024 * 1024; // 4MB
 const REQUIRE_EXECUTABLE_SIGNATURES: bool = true;
 
@@ -200,8 +204,8 @@ pub fn download_and_flash(catalog_url: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Write firmware data to the ota_1 partition
-fn flash_to_ota1(data: &[u8]) -> anyhow::Result<()> {
+/// Write firmware data to the inactive OTA partition without selecting it.
+fn write_ota1(data: &[u8]) -> anyhow::Result<()> {
     unsafe {
         let part = esp_ota_get_next_update_partition(std::ptr::null());
         if part.is_null() {
@@ -245,14 +249,32 @@ fn flash_to_ota1(data: &[u8]) -> anyhow::Result<()> {
             anyhow::bail!("esp_ota_end failed: {}", ret);
         }
 
+        info!("OTA flash complete; boot partition remains unchanged");
+        Ok(())
+    }
+}
+
+/// Select the already-written OTA partition. Bundle installs call this only
+/// after the complete filesystem generation is active and recoverable.
+fn select_ota1_for_boot() -> anyhow::Result<()> {
+    unsafe {
+        let part = esp_ota_get_next_update_partition(std::ptr::null());
+        if part.is_null() {
+            anyhow::bail!("No OTA update partition");
+        }
         let ret = esp_ota_set_boot_partition(part);
         if ret != ESP_OK as i32 {
             anyhow::bail!("esp_ota_set_boot_partition failed: {}", ret);
         }
-
-        info!("OTA flash complete, boot partition set");
+        info!("OTA boot partition selected");
         Ok(())
     }
+}
+
+/// Write and select firmware for single-image update workflows.
+fn flash_to_ota1(data: &[u8]) -> anyhow::Result<()> {
+    write_ota1(data)?;
+    select_ota1_for_boot()
 }
 
 // ---------------------------------------------------------------------------
@@ -1166,15 +1188,9 @@ pub fn recovery_download_board_bundle(catalog_url: &str) -> anyhow::Result<u32> 
 ///   - board entries: matched by `id`/`board_id`.
 ///   - all entries: filtered by detected chip `arch` when present.
 ///
-/// Steps:
-/// 1. Fetch catalog JSON from `catalog_url`.
-/// 2. Count compatible entries to compute per-item progress increments.
-/// 3. For each compatible catalog entry:
-///    - firmware → verified and flashed directly to ota_1
-///    - board    → /sdcard/config/boards/<id>.json and /sdcard/config/board.json
-///    - driver   → /sdcard/drivers/<id>.drv.elf
-///    - wm       → /sdcard/wm/<id>.wm.elf
-/// 4. Verify and store matching .sig files alongside non-firmware bundle files.
+/// All matching artifacts are downloaded and verified before any active file
+/// changes. Files are then staged as one journaled generation, firmware is
+/// written without changing the boot selector, and boot selection happens last.
 ///
 /// Returns the number of items successfully downloaded.
 pub fn recovery_download_board_bundle_for(
@@ -1220,8 +1236,17 @@ pub fn recovery_download_board_bundle_for(
         .filter(|obj| entry_should_download(obj))
         .count() as u32;
 
+    if total_entries == 0 {
+        anyhow::bail!(
+            "Catalog has no compatible bundle entries for '{}'",
+            board_name
+        );
+    }
+
     let mut downloaded = 0u32;
-    let mut errors = 0u32;
+    let download_stage = DownloadStage::new(Path::new(BUNDLE_DOWNLOAD_DIR))?;
+    let mut bundle_files = Vec::new();
+    let mut firmware_path: Option<std::path::PathBuf> = None;
 
     for obj in iter_json_objects(&catalog_json) {
         if !entry_should_download(obj) {
@@ -1231,12 +1256,12 @@ pub fn recovery_download_board_bundle_for(
         let entry_type = json_extract_string(obj, "type").unwrap_or_default();
         let id = match json_extract_string(obj, "id") {
             Some(v) => v,
-            None => continue,
+            None => anyhow::bail!("Compatible catalog entry is missing id"),
         };
         validate_catalog_id(&id).map_err(anyhow::Error::msg)?;
         let url = match json_extract_string(obj, "url") {
             Some(v) => v,
-            None => continue,
+            None => anyhow::bail!("Compatible catalog entry '{}' is missing url", id),
         };
         let sig_url = json_extract_string(obj, "sig_url");
         let expected_sha = json_extract_string(obj, "sha256");
@@ -1258,79 +1283,73 @@ pub fn recovery_download_board_bundle_for(
 
         if entry_type == "firmware" {
             let Some(expected_sha) = expected_sha.as_deref().filter(|s| !s.is_empty()) else {
-                error!("Firmware '{}' missing sha256 — skipping install", name);
-                errors += 1;
-                continue;
+                anyhow::bail!("Firmware '{}' is missing sha256", name);
             };
-            info!("Downloading firmware {} -> ota_1", name);
-            println!("  {} [firmware -> ota_1]", name);
-            match download_catalog_entry_bytes(
+            if firmware_path.is_some() {
+                anyhow::bail!("Catalog contains multiple compatible firmware images");
+            }
+            info!("Downloading and verifying firmware {}", name);
+            println!("  {} [firmware, staged in memory]", name);
+            let (data, _) = download_catalog_entry_bytes(
                 &url,
                 Some(expected_sha),
                 sig_url.as_deref(),
                 REQUIRE_EXECUTABLE_SIGNATURES,
-            )
-            .and_then(|(data, _)| flash_to_ota1(&data))
-            {
-                Ok(()) => {
-                    downloaded += 1;
-                    info!("Firmware '{}' flashed to ota_1", name);
-                    if total_entries > 0 {
-                        let pct = (downloaded * 100 / total_entries).min(99) as u8;
-                        BUNDLE_PROGRESS.store(pct, Ordering::Relaxed);
-                    }
-                }
-                Err(e) => {
-                    error!("Failed to flash firmware '{}': {}", name, e);
-                    errors += 1;
-                }
+            )?;
+            let staged = download_stage.write(&format!("{}-firmware.bin", downloaded), &data)?;
+            firmware_path = Some(staged);
+        } else {
+            info!("Downloading and verifying {} -> {}", name, dest_path);
+            println!("  {} [{}]", name, entry_type);
+            let require_signature =
+                matches!(entry_type.as_str(), "driver" | "wm") && REQUIRE_EXECUTABLE_SIGNATURES;
+            let (data, signature) = download_catalog_entry_bytes(
+                &url,
+                expected_sha.as_deref(),
+                sig_url.as_deref(),
+                require_signature,
+            )?;
+            let relative = sdcard_relative_path(&dest_path)?;
+            let staged = download_stage.write(&format!("{}-payload", downloaded), &data)?;
+            if entry_type == "board" {
+                bundle_files.push(BundleFile::from_file("config/board.json", &staged)?);
             }
-            continue;
-        }
-
-        info!("Downloading {} -> {}", name, dest_path);
-        println!("  {} [{}]", name, entry_type);
-
-        let require_signature =
-            matches!(entry_type.as_str(), "driver" | "wm") && REQUIRE_EXECUTABLE_SIGNATURES;
-        if let Err(e) = download_file(
-            &url,
-            expected_sha.as_deref(),
-            sig_url.as_deref(),
-            require_signature,
-            &dest_path,
-        ) {
-            error!("Failed to download '{}': {}", name, e);
-            errors += 1;
-            continue;
-        }
-
-        if entry_type == "board" {
-            let _ = std::fs::create_dir_all("/sdcard/config");
-            let _ = std::fs::copy(&dest_path, "/sdcard/config/board.json");
-        }
-
-        if !sig_url.as_deref().unwrap_or_default().is_empty() {
-            info!("Signature downloaded for '{}'", name);
+            bundle_files.push(BundleFile::from_file(&relative, &staged)?);
+            if let Some(signature) = signature {
+                let signature_path = format!("{}.sig", relative.to_string_lossy());
+                let staged_signature =
+                    download_stage.write(&format!("{}-signature", downloaded), &signature)?;
+                bundle_files.push(BundleFile::from_file(signature_path, staged_signature)?);
+                info!("Signature downloaded for '{}'", name);
+            }
         }
 
         downloaded += 1;
-        info!("Installed '{}'", name);
+        info!("Verified '{}'", name);
 
         // Update progress
         if total_entries > 0 {
-            let pct = (downloaded * 100 / total_entries).min(99) as u8;
+            let pct = (downloaded * 80 / total_entries).min(80) as u8;
             BUNDLE_PROGRESS.store(pct, Ordering::Relaxed);
         }
     }
 
-    if errors > 0 {
-        anyhow::bail!(
-            "Bundle download completed with {} error(s) ({} succeeded)",
-            errors,
-            downloaded
-        );
-    }
+    let firmware_path =
+        firmware_path.ok_or_else(|| anyhow::anyhow!("Catalog has no compatible firmware image"))?;
+    let sdcard_root = Path::new("/sdcard");
+    bundle_transaction::install(
+        sdcard_root,
+        &bundle_files,
+        || {
+            let firmware_data = std::fs::read(&firmware_path)?;
+            write_ota1(&firmware_data).map_err(transaction_io_error)
+        },
+        || select_ota1_for_boot().map_err(transaction_io_error),
+        |boundary| {
+            log_transaction_boundary(boundary);
+            Ok(())
+        },
+    )?;
 
     BUNDLE_PROGRESS.store(100, Ordering::Relaxed);
     info!(
@@ -1339,6 +1358,83 @@ pub fn recovery_download_board_bundle_for(
     );
     println!("Bundle complete: {} items installed", downloaded);
     Ok(downloaded)
+}
+
+fn sdcard_relative_path(path: &str) -> anyhow::Result<std::path::PathBuf> {
+    Path::new(path)
+        .strip_prefix("/sdcard")
+        .map(|relative| relative.to_path_buf())
+        .map_err(|_| anyhow::anyhow!("Bundle destination is outside /sdcard: {}", path))
+}
+
+fn transaction_io_error(error: anyhow::Error) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, error.to_string())
+}
+
+struct DownloadStage {
+    root: std::path::PathBuf,
+}
+
+impl DownloadStage {
+    fn new(root: &Path) -> io::Result<Self> {
+        if root.exists() {
+            std::fs::remove_dir_all(root)?;
+        }
+        std::fs::create_dir_all(root)?;
+        Ok(Self {
+            root: root.to_path_buf(),
+        })
+    }
+
+    fn write(&self, name: &str, data: &[u8]) -> io::Result<std::path::PathBuf> {
+        let path = self.root.join(name);
+        let mut file = std::fs::File::create(&path)?;
+        std::io::Write::write_all(&mut file, data)?;
+        file.sync_all()?;
+        Ok(path)
+    }
+}
+
+impl Drop for DownloadStage {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+fn log_transaction_boundary(boundary: Boundary) {
+    info!("Bundle transaction boundary: {:?}", boundary);
+}
+
+/// Resolve a transaction left by a reset, failed boot, or failed cleanup.
+/// Only a firmware image that reached ESP-IDF's VALID state may commit the
+/// matching filesystem generation; every other state restores the old files.
+pub fn recover_interrupted_bundle() -> anyhow::Result<()> {
+    let root = Path::new("/sdcard");
+    let ota_selected = ota1_is_boot_partition();
+    let ota_valid = matches!(check_ota1(), Ota1State::Valid);
+    match bundle_transaction::recovery_action(root, ota_selected, ota_valid)? {
+        RecoveryAction::None => {}
+        RecoveryAction::Rollback => {
+            warn!("Rolling back interrupted bundle transaction");
+            bundle_transaction::rollback(root)?;
+        }
+        RecoveryAction::Finalize => {
+            info!("Finalizing confirmed bundle transaction");
+            bundle_transaction::finalize(root)?;
+        }
+    }
+    if Path::new(BUNDLE_DOWNLOAD_DIR).exists() {
+        std::fs::remove_dir_all(BUNDLE_DOWNLOAD_DIR)?;
+    }
+    Ok(())
+}
+
+fn ota1_is_boot_partition() -> bool {
+    unsafe {
+        let ota1 = esp_ota_get_next_update_partition(std::ptr::null());
+        let selected = esp_ota_get_boot_partition();
+        !ota1.is_null() && selected == ota1
+    }
 }
 
 /// Build a dry-run JSON plan for the bundle entries recovery would download.


### PR DESCRIPTION
Closes #39

## What changed
- download and verify the complete compatible bundle before touching active files
- stage filesystem artifacts on SD and activate them through a persistent rollback journal
- write firmware without changing the boot selector, then select the OTA partition last
- restore the prior filesystem generation whenever Recovery observes an interrupted or failed boot
- retain rollback files until the new image reaches the healthy-boot milestone, then finalize them
- use one-way FAT-safe phase markers and require both selected + valid OTA state before commit

## Verification
- `rustc --edition=2021 --test recovery/src/bundle_transaction.rs` (5 passed)
- `cargo test --manifest-path components/kernel_rs/Cargo.toml --target aarch64-apple-darwin -- --test-threads=1` (1317 passed)
- `cargo +esp check` in `recovery/`
- full ESP-IDF v5.5 ESP32-S3 firmware and bootloader build (13% app partition free)
- `git diff --check`

## Failure coverage
The transaction tests inject failures at staging, journal creation, every backup/activation move, both phase transitions, firmware write, and boot selection. They also simulate recovery after power loss during each filesystem move and assert that the original generation is restored.