### PR TITLE
Secure Recovery provisioning and control

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,6 +111,16 @@ jobs:
             -o /tmp/test_bounded_io
           /tmp/test_bounded_io
 
+      - name: Test Recovery provisioning authorization
+        run: |
+          rustc --edition=2021 --test recovery/src/recovery_auth.rs \
+            -o /tmp/test_recovery_auth
+          /tmp/test_recovery_auth
+          test "$(grep -c 'authorize_mutation(&req)' recovery/src/recovery_web.rs)" -eq 4
+          grep -q "AuthMethod::WPA2Personal" recovery/src/main.rs
+          ! grep -q "AuthMethod::None" recovery/src/main.rs
+          test "$(grep -c "authFetch('/api/" recovery/src/recovery_web.rs)" -eq 7
+
   simulator-boot:
     name: Simulator Boot Test
     runs-on: ubuntu-latest

--- a/recovery/src/main.rs
+++ b/recovery/src/main.rs
@@ -25,11 +25,13 @@ use log::*;
 mod bounded_io;
 mod bundle_transaction;
 mod catalog_path;
+mod recovery_auth;
 mod recovery_ota;
 mod recovery_web;
 
 const VERSION: &str = "0.1.0";
-const AP_SSID: &str = "ThistleOS-Recovery";
+const AP_SSID_PREFIX: &str = "ThistleOS-Recovery";
+const RECOVERY_SESSION_TTL_MS: u64 = 30 * 60 * 1000;
 const BUNDLE_CATALOG_URL: &str = "https://wan0net.github.io/thistle-apps/catalog.json";
 const BOARD_CATALOG_URL: &str = "https://wan0net.github.io/thistle-os/catalog.json";
 
@@ -109,11 +111,8 @@ fn main() -> anyhow::Result<()> {
     // so it does not drive board-specific pins before the user selects hardware.
     println!("Board selection is catalog-driven — select your board in the web UI");
 
-    // Step 3: Start WiFi AP + captive portal
-    info!("Starting WiFi Access Point: {}", AP_SSID);
-    println!("\nStarting WiFi hotspot: {}", AP_SSID);
-    println!("Connect your phone/laptop and open http://192.168.4.1");
-
+    // Step 3: Start an encrypted WiFi AP. The per-boot password will be shown
+    // only on the physically attached recovery console.
     // Seed catalog URLs in shared state so handlers can reference them.
     {
         let mut st = recovery_web::STATE.lock().unwrap();
@@ -132,19 +131,43 @@ fn main() -> anyhow::Result<()> {
         sysloop.clone(),
     )?;
 
+    // ESP-IDF documents esp_random() as a true hardware random source while
+    // WiFi is enabled. Start STA mode without connecting, generate the pairing
+    // secrets, then restart in the final encrypted AP+STA configuration.
+    wifi.set_configuration(&Configuration::Client(ClientConfiguration::default()))?;
+    wifi.start()?;
+    let ap_ssid = format!("{}-{}", AP_SSID_PREFIX, random_base32(4));
+    let ap_password = random_base32(16);
+    let recovery_token = random_hex(32);
+    wifi.stop()?;
+
+    info!("Starting encrypted WiFi Access Point: {}", ap_ssid);
+    println!("\nStarting WiFi hotspot: {}", ap_ssid);
+    println!("Recovery WiFi password: {}", ap_password);
+    println!("Connect your phone/laptop and open http://192.168.4.1");
+    {
+        let mut st = recovery_web::STATE.lock().unwrap();
+        st.session = Some(recovery_auth::RecoverySession::new(
+            recovery_token,
+            recovery_web::monotonic_ms(),
+            RECOVERY_SESSION_TTL_MS,
+        ));
+    }
+
     // Configure as AP (hotspot) + STA (client) simultaneously
     wifi.set_configuration(&Configuration::Mixed(
         ClientConfiguration::default(),
         AccessPointConfiguration {
-            ssid: AP_SSID.try_into().unwrap(),
-            auth_method: AuthMethod::None,
+            ssid: ap_ssid.as_str().try_into().unwrap(),
+            password: ap_password.as_str().try_into().unwrap(),
+            auth_method: AuthMethod::WPA2Personal,
             max_connections: 4,
             ..Default::default()
         },
     ))?;
 
     wifi.start()?;
-    info!("WiFi AP started: {} (192.168.4.1)", AP_SSID);
+    info!("WiFi AP started: {} (192.168.4.1)", ap_ssid);
 
     // Step 4: Start HTTP server for captive portal
     let mut server = EspHttpServer::new(&HttpConfig::default())?;
@@ -157,12 +180,12 @@ fn main() -> anyhow::Result<()> {
     println!("========================================");
     println!(
         "Use http://192.168.4.1 from any device connected to '{}'.",
-        AP_SSID
+        ap_ssid
     );
     println!("Recovery will keep polling web requests until install/reboot.");
 
     loop {
-        poll_web_state(&mut wifi);
+        poll_web_state(&mut wifi, &ap_ssid, &ap_password);
         FreeRtos::delay_ms(100);
     }
 }
@@ -171,7 +194,7 @@ fn main() -> anyhow::Result<()> {
 // Poll shared web UI state and act on any pending requests
 // ---------------------------------------------------------------------------
 
-fn poll_web_state(wifi: &mut BlockingWifi<EspWifi>) {
+fn poll_web_state(wifi: &mut BlockingWifi<EspWifi>, ap_ssid: &str, ap_password: &str) {
     // Check for pending WiFi connect request from web UI
     let wifi_req = {
         let mut st = recovery_web::STATE.lock().unwrap();
@@ -180,7 +203,7 @@ fn poll_web_state(wifi: &mut BlockingWifi<EspWifi>) {
 
     if let Some((ssid, pass)) = wifi_req {
         info!("Web UI requested WiFi connect to '{}'", ssid);
-        match do_wifi_connect(wifi, &ssid, &pass) {
+        match do_wifi_connect(wifi, &ssid, &pass, ap_ssid, ap_password) {
             Ok(ip) => {
                 info!("Web UI WiFi connect succeeded: {}", ip);
                 let mut st = recovery_web::STATE.lock().unwrap();
@@ -241,6 +264,8 @@ fn do_wifi_connect(
     wifi: &mut BlockingWifi<EspWifi>,
     ssid: &str,
     pass: &str,
+    ap_ssid: &str,
+    ap_password: &str,
 ) -> anyhow::Result<String> {
     wifi.set_configuration(&Configuration::Mixed(
         ClientConfiguration {
@@ -249,8 +274,9 @@ fn do_wifi_connect(
             ..Default::default()
         },
         AccessPointConfiguration {
-            ssid: AP_SSID.try_into().unwrap(),
-            auth_method: AuthMethod::None,
+            ssid: ap_ssid.try_into().unwrap(),
+            password: ap_password.try_into().unwrap(),
+            auth_method: AuthMethod::WPA2Personal,
             max_connections: 4,
             ..Default::default()
         },
@@ -267,4 +293,32 @@ fn do_wifi_connect(
         .unwrap_or_else(|_| "assigned".to_string());
 
     Ok(ip)
+}
+
+fn random_base32(length: usize) -> String {
+    const ALPHABET: &[u8; 32] = b"ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    (0..length)
+        .map(|_| {
+            let random = unsafe { esp_idf_sys::esp_random() };
+            ALPHABET[(random as usize) & 31] as char
+        })
+        .collect()
+}
+
+fn random_hex(byte_length: usize) -> String {
+    let mut result = String::with_capacity(byte_length * 2);
+    let mut generated = 0;
+    while generated < byte_length {
+        // esp_random() is the ESP-IDF hardware random source.
+        let random = unsafe { esp_idf_sys::esp_random() };
+        for byte in random.to_le_bytes() {
+            if generated == byte_length {
+                break;
+            }
+            use std::fmt::Write;
+            let _ = write!(result, "{:02x}", byte);
+            generated += 1;
+        }
+    }
+    result
 }

--- a/recovery/src/recovery_auth.rs
+++ b/recovery/src/recovery_auth.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Pure authorization state for Recovery's local provisioning session.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AuthFailure {
+    Unauthorized,
+    Replay,
+    Expired,
+}
+
+pub struct RecoverySession {
+    token: String,
+    expires_at_ms: u64,
+    last_nonce: u64,
+    active: bool,
+}
+
+impl RecoverySession {
+    pub fn new(token: String, now_ms: u64, ttl_ms: u64) -> Self {
+        Self {
+            token,
+            expires_at_ms: now_ms.saturating_add(ttl_ms),
+            last_nonce: 0,
+            active: true,
+        }
+    }
+
+    pub fn authorize(
+        &mut self,
+        supplied_token: Option<&str>,
+        supplied_nonce: Option<&str>,
+        now_ms: u64,
+    ) -> Result<(), AuthFailure> {
+        if !self.active || now_ms >= self.expires_at_ms {
+            self.active = false;
+            self.token.clear();
+            return Err(AuthFailure::Expired);
+        }
+
+        let token = supplied_token.ok_or(AuthFailure::Unauthorized)?;
+        if !constant_time_eq(self.token.as_bytes(), token.as_bytes()) {
+            return Err(AuthFailure::Unauthorized);
+        }
+
+        let nonce = supplied_nonce
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .ok_or(AuthFailure::Unauthorized)?;
+        if nonce <= self.last_nonce {
+            return Err(AuthFailure::Replay);
+        }
+
+        self.last_nonce = nonce;
+        Ok(())
+    }
+
+    pub fn expire(&mut self) {
+        self.active = false;
+        self.token.clear();
+    }
+
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    pub fn next_nonce(&self) -> u64 {
+        self.last_nonce.saturating_add(1)
+    }
+}
+
+fn constant_time_eq(expected: &[u8], supplied: &[u8]) -> bool {
+    let mut difference = expected.len() ^ supplied.len();
+    for (index, expected_byte) in expected.iter().enumerate() {
+        difference |= usize::from(*expected_byte ^ supplied.get(index).copied().unwrap_or(0));
+    }
+    difference == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TOKEN: &str = "6f6e652d74696d652d7265636f766572792d73657373696f6e";
+
+    #[test]
+    fn missing_and_invalid_authorization_are_rejected() {
+        let mut session = RecoverySession::new(TOKEN.to_string(), 1_000, 60_000);
+        assert_eq!(
+            session.authorize(None, Some("1"), 1_001),
+            Err(AuthFailure::Unauthorized)
+        );
+        assert_eq!(
+            session.authorize(Some("wrong"), Some("1"), 1_001),
+            Err(AuthFailure::Unauthorized)
+        );
+        assert_eq!(
+            session.authorize(Some(TOKEN), None, 1_001),
+            Err(AuthFailure::Unauthorized)
+        );
+        assert_eq!(
+            session.authorize(Some(TOKEN), Some("not-a-number"), 1_001),
+            Err(AuthFailure::Unauthorized)
+        );
+    }
+
+    #[test]
+    fn consumed_nonce_cannot_be_replayed() {
+        let mut session = RecoverySession::new(TOKEN.to_string(), 1_000, 60_000);
+        assert_eq!(session.authorize(Some(TOKEN), Some("7"), 1_001), Ok(()));
+        assert_eq!(session.next_nonce(), 8);
+        assert_eq!(
+            session.authorize(Some(TOKEN), Some("7"), 1_002),
+            Err(AuthFailure::Replay)
+        );
+        assert_eq!(
+            session.authorize(Some(TOKEN), Some("6"), 1_002),
+            Err(AuthFailure::Replay)
+        );
+        assert_eq!(session.authorize(Some(TOKEN), Some("9"), 1_002), Ok(()));
+    }
+
+    #[test]
+    fn expired_and_explicitly_closed_sessions_reject_every_token() {
+        let mut expired = RecoverySession::new(TOKEN.to_string(), 1_000, 500);
+        assert_eq!(
+            expired.authorize(Some(TOKEN), Some("1"), 1_500),
+            Err(AuthFailure::Expired)
+        );
+        assert_eq!(expired.token(), "");
+
+        let mut closed = RecoverySession::new(TOKEN.to_string(), 1_000, 500);
+        closed.expire();
+        assert_eq!(closed.token(), "");
+        assert_eq!(
+            closed.authorize(Some(TOKEN), Some("1"), 1_001),
+            Err(AuthFailure::Expired)
+        );
+    }
+}

--- a/recovery/src/recovery_web.rs
+++ b/recovery/src/recovery_web.rs
@@ -41,6 +41,8 @@ pub struct RecoveryState {
     pub board_catalog_url: String,
     /// Chip slug detected at boot, e.g. "esp32s3", "esp32c3".
     pub chip: String,
+    /// Short-lived bearer session for state-changing provisioning requests.
+    pub session: Option<crate::recovery_auth::RecoverySession>,
 }
 
 impl RecoveryState {
@@ -57,6 +59,7 @@ impl RecoveryState {
             catalog_url: String::new(),
             board_catalog_url: String::new(),
             chip: String::new(),
+            session: None,
         }
     }
 }
@@ -225,6 +228,16 @@ var wifiConnected = false;
 var boardSelected = null;
 var pollTimer = null;
 var bundlePollTimer = null;
+var recoveryToken = '__RECOVERY_TOKEN__';
+var recoveryNonce = __RECOVERY_NONCE__;
+
+function authFetch(url, options) {
+  options = options || {};
+  options.headers = options.headers || {};
+  options.headers['X-Recovery-Token'] = recoveryToken;
+  options.headers['X-Recovery-Nonce'] = String(recoveryNonce++);
+  return fetch(url, options);
+}
 
 // ---------------------------------------------------------------------------
 // Initialise board list and optional components from /api/boards
@@ -300,7 +313,7 @@ function initBoards() {
       if (d.detected) {
         document.getElementById('board-btn').disabled = false;
         document.getElementById('plan-btn').disabled = false;
-        fetch('/api/board/select', {
+        authFetch('/api/board/select', {
           method: 'POST',
           headers: {'Content-Type':'application/json'},
           body: JSON.stringify({board: d.detected})
@@ -371,7 +384,7 @@ function connectWifi(e) {
   showStatus(st, 'Connecting...', 'info');
   btn.disabled = true;
 
-  fetch('/api/wifi/connect', {
+  authFetch('/api/wifi/connect', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({ssid: ssid, password: pass})
@@ -456,7 +469,7 @@ function selectBoard() {
   btn.disabled = true;
   showStatus(st, 'Saving...', 'info');
 
-  fetch('/api/board/select', {
+  authFetch('/api/board/select', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({board: boardSelected})
@@ -481,7 +494,7 @@ function planInstall() {
   if (!boardSelected) { return; }
   var st = document.getElementById('board-status');
   showStatus(st, 'Checking install plan...', 'info');
-  fetch('/api/board/select', {
+  authFetch('/api/board/select', {
     method: 'POST',
     headers: {'Content-Type':'application/json'},
     body: JSON.stringify({board: boardSelected})
@@ -522,7 +535,7 @@ function startInstall() {
   bar.style.width = '5%';
   showStatus(st, 'Starting download...', 'info');
 
-  fetch('/api/bundle/download', {method: 'POST'})
+  authFetch('/api/bundle/download', {method: 'POST'})
     .then(function(r) { return r.json(); })
     .then(function(d) {
       if (d.ok) {
@@ -579,7 +592,7 @@ function setInstallDone(items) {
     showStatus(st, 'Installed ' + items + ' item(s). Rebooting in ' + countdown + suffix + '...', '');
     if (countdown <= 0) {
       showStatus(st, 'Rebooting now...', '');
-      fetch('/api/reboot', {method: 'POST'}).catch(function() {});
+      authFetch('/api/reboot', {method: 'POST'}).catch(function() {});
       return;
     }
     countdown--;
@@ -597,7 +610,7 @@ function viewStatus() {
 
 function confirmReboot() {
   if (confirm('Reboot the device now?')) {
-    fetch('/api/reboot', {method: 'POST'}).catch(function() {});
+    authFetch('/api/reboot', {method: 'POST'}).catch(function() {});
   }
 }
 
@@ -627,8 +640,22 @@ pub fn register_handlers(server: &mut EspHttpServer) -> anyhow::Result<()> {
         "/",
         esp_idf_svc::http::Method::Get,
         |req| -> anyhow::Result<()> {
-            let mut resp = req.into_response(200, None, &[("Content-Type", "text/html")])?;
-            resp.write(RECOVERY_HTML.as_bytes())?;
+            let (token, nonce) = {
+                let st = STATE.lock().unwrap();
+                st.session
+                    .as_ref()
+                    .map(|session| (session.token().to_string(), session.next_nonce()))
+                    .unwrap_or_else(|| (String::new(), 1))
+            };
+            let page = RECOVERY_HTML
+                .replace("__RECOVERY_TOKEN__", &token)
+                .replace("__RECOVERY_NONCE__", &nonce.to_string());
+            let mut resp = req.into_response(
+                200,
+                None,
+                &[("Content-Type", "text/html"), ("Cache-Control", "no-store")],
+            )?;
+            resp.write(page.as_bytes())?;
             Ok(())
         },
     )?;
@@ -790,6 +817,9 @@ pub fn register_handlers(server: &mut EspHttpServer) -> anyhow::Result<()> {
         "/api/wifi/connect",
         esp_idf_svc::http::Method::Post,
         |mut req| -> anyhow::Result<()> {
+            if let Err(failure) = authorize_mutation(&req) {
+                return respond_auth_failure(req, failure);
+            }
             let body = match read_request_body(&mut req, MAX_WIFI_REQUEST_BODY) {
                 Ok(body) => body,
                 Err(error) => {
@@ -832,6 +862,9 @@ pub fn register_handlers(server: &mut EspHttpServer) -> anyhow::Result<()> {
         "/api/board/select",
         esp_idf_svc::http::Method::Post,
         |mut req| -> anyhow::Result<()> {
+            if let Err(failure) = authorize_mutation(&req) {
+                return respond_auth_failure(req, failure);
+            }
             let body = match read_request_body(&mut req, MAX_BOARD_REQUEST_BODY) {
                 Ok(body) => body,
                 Err(error) => {
@@ -926,6 +959,9 @@ pub fn register_handlers(server: &mut EspHttpServer) -> anyhow::Result<()> {
         "/api/bundle/download",
         esp_idf_svc::http::Method::Post,
         |req| -> anyhow::Result<()> {
+            if let Err(failure) = authorize_mutation(&req) {
+                return respond_auth_failure(req, failure);
+            }
             let (has_board, already_downloading) = {
                 let st = STATE.lock().unwrap();
                 (st.board_name.is_some(), st.bundle_status == "downloading")
@@ -1001,6 +1037,12 @@ pub fn register_handlers(server: &mut EspHttpServer) -> anyhow::Result<()> {
         "/api/reboot",
         esp_idf_svc::http::Method::Post,
         |req| -> anyhow::Result<()> {
+            if let Err(failure) = authorize_mutation(&req) {
+                return respond_auth_failure(req, failure);
+            }
+            if let Some(session) = STATE.lock().unwrap().session.as_mut() {
+                session.expire();
+            }
             let mut resp = req.into_response(200, None, &[("Content-Type", "application/json")])?;
             resp.write(b"{\"ok\":true}")?;
             info!("Reboot requested via web UI");
@@ -1013,6 +1055,47 @@ pub fn register_handlers(server: &mut EspHttpServer) -> anyhow::Result<()> {
     )?;
 
     info!("Web UI handlers registered (captive portal active)");
+    Ok(())
+}
+
+pub fn monotonic_ms() -> u64 {
+    let micros = unsafe { esp_idf_sys::esp_timer_get_time() };
+    u64::try_from(micros.max(0)).unwrap_or(0) / 1_000
+}
+
+fn authorize_mutation(
+    req: &embedded_svc::http::server::Request<&mut EspHttpConnection<'_>>,
+) -> Result<(), crate::recovery_auth::AuthFailure> {
+    let token = req.header("X-Recovery-Token");
+    let nonce = req.header("X-Recovery-Nonce");
+    let mut state = STATE.lock().unwrap();
+    let session = state
+        .session
+        .as_mut()
+        .ok_or(crate::recovery_auth::AuthFailure::Expired)?;
+    session.authorize(token, nonce, monotonic_ms())
+}
+
+fn respond_auth_failure(
+    req: embedded_svc::http::server::Request<&mut EspHttpConnection<'_>>,
+    failure: crate::recovery_auth::AuthFailure,
+) -> anyhow::Result<()> {
+    let (status, error) = match failure {
+        crate::recovery_auth::AuthFailure::Replay => (409, "replayed authorization"),
+        crate::recovery_auth::AuthFailure::Expired => (401, "pairing session expired"),
+        crate::recovery_auth::AuthFailure::Unauthorized => (401, "unauthorized"),
+    };
+    warn!("Rejected Recovery mutation: {}", error);
+    let body = format!(r#"{{"ok":false,"error":"{}"}}"#, error);
+    let mut resp = req.into_response(
+        status,
+        None,
+        &[
+            ("Content-Type", "application/json"),
+            ("Cache-Control", "no-store"),
+        ],
+    )?;
+    resp.write(body.as_bytes())?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- replace the shared open Recovery AP with a uniquely named WPA2 access point and a fresh 16-character password shown only on the attached recovery console
- generate AP and session secrets only while ESP-IDF WiFi entropy is active
- require a short-lived 256-bit pairing token and monotonically increasing nonce on every WiFi-connect, board-select, bundle-install, and reboot request
- reject missing/invalid authorization, replayed nonces, expired sessions, and requests after the session is closed for reboot
- preserve the encrypted AP configuration when Recovery connects its STA interface to the user's network
- mark token-bearing HTML and authorization errors as non-cacheable

## Security invariant

Only a client that joined the randomly protected Recovery AP and loaded the current provisioning page can submit state-changing requests. Each accepted request consumes its nonce, and the session expires after 30 minutes or immediately when provisioning reboots the device.

## Validation

- Recovery authorization unit tests: missing, invalid, malformed, replayed, expired, and explicitly closed sessions
- Recovery HTTP boundary tests: 6 passed
- `cargo +esp check`: passed
- optimized ESP32-S3 Recovery build: passed, 1.6 MB (within the 2.5 MB partition)
- formatting and patch checks: passed

Closes #40
