### PR TITLE
Bind Recovery installs to signed artifact manifests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,17 +90,55 @@ jobs:
           apt-get update
           apt-get install -y python3-venv
           python3 -m venv /tmp/thistle-signing-venv
-          /tmp/thistle-signing-venv/bin/pip install PyNaCl
+          /tmp/thistle-signing-venv/bin/pip install -r tools/requirements.txt
           /tmp/thistle-signing-venv/bin/python -c "
-          import nacl.signing, os
+          import json, os, pathlib, re
+          from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+          from tools.sign import canonical_manifest
           key_hex = os.environ['THISTLE_SIGNING_KEY']
-          sk = nacl.signing.SigningKey(bytes.fromhex(key_hex))
+          sk = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(key_hex))
           data = open('build/thistle_os.bin', 'rb').read()
-          signed = sk.sign(data)
-          sig = signed.signature  # 64-byte Ed25519 signature
+          sig = sk.sign(data)
           open('build/thistle_os.bin.sig', 'wb').write(sig)
-          vk = sk.verify_key
-          open('build/thistle_os.bin.pub', 'wb').write(vk.encode())
+          open('build/thistle_os.bin.pub', 'wb').write(sk.public_key().public_bytes_raw())
+          source = pathlib.Path('components/kernel_rs/src/version.rs').read_text()
+          version = re.search(r'VERSION_STRING: &str = \"([^\"]+)\"', source).group(1)
+          security_version = int(re.search(r'SECURITY_VERSION: u32 = ([0-9]+)', source).group(1))
+          boards = sorted(
+              json.loads(path.read_text())['board']['board_id']
+              for path in pathlib.Path('sdcard_layout/config/boards').glob('*.json')
+              if json.loads(path.read_text()).get('board', {}).get('arch') == 'esp32s3'
+          )
+          manifest = canonical_manifest(
+              artifact_type='firmware', artifact_id='thistle-os', version=version,
+              security_version=security_version, arch='esp32s3',
+              compatible_boards=boards,
+              url=f'https://github.com/{os.environ[\"GITHUB_REPOSITORY\"]}/releases/download/v{version}/thistle_os-v{version}.bin',
+              payload=data,
+          )
+          open('build/thistle_os.bin.manifest', 'wb').write(manifest)
+          open('build/thistle_os.bin.manifest.sig', 'wb').write(sk.sign(manifest))
+          board_output = pathlib.Path('build/signed-board-profiles')
+          board_output.mkdir(exist_ok=True)
+          for path in pathlib.Path('sdcard_layout/config/boards').glob('*.json'):
+              profile = json.loads(path.read_text())
+              metadata = profile['board']
+              board_id = metadata['board_id']
+              profile_version = metadata.get('version', '1.0.0')
+              if profile_version.count('.') == 1:
+                  profile_version += '.0'
+              output = board_output / f'board-{board_id}.json'
+              payload = path.read_bytes()
+              output.write_bytes(payload)
+              board_manifest = canonical_manifest(
+                  artifact_type='board', artifact_id=board_id,
+                  version=profile_version, security_version=1,
+                  arch=metadata['arch'], compatible_boards=[board_id],
+                  url=f'https://github.com/{os.environ[\"GITHUB_REPOSITORY\"]}/releases/download/v{version}/{output.name}',
+                  payload=payload,
+              )
+              pathlib.Path(f'{output}.manifest').write_bytes(board_manifest)
+              pathlib.Path(f'{output}.manifest.sig').write_bytes(sk.sign(board_manifest))
           print(f'Signed: {len(data)} bytes, sig: {sig.hex()[:32]}...')
           "
 
@@ -111,7 +149,10 @@ jobs:
           path: |
             build/thistle_os.bin
             build/thistle_os.bin.sig
+            build/thistle_os.bin.manifest
+            build/thistle_os.bin.manifest.sig
             build/thistle_os.bin.pub
+            build/signed-board-profiles/
 
   rust-tests:
     name: Rust Kernel Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,19 @@ jobs:
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
+          manifest="release-artifacts/thistle-os-firmware/thistle_os.bin.manifest"
+          manifest_version="$(sed -n 's/^version=//p' "$manifest")"
+          if [ "$RELEASE_TAG" != "v$manifest_version" ]; then
+            echo "ERROR: release tag $RELEASE_TAG does not match signed manifest version $manifest_version" >&2
+            exit 1
+          fi
           mkdir -p dist
           cp release-artifacts/thistle-os-firmware/thistle_os.bin "dist/thistle_os-${RELEASE_TAG}.bin"
           cp release-artifacts/thistle-os-firmware/thistle_os.bin.sig "dist/thistle_os-${RELEASE_TAG}.bin.sig"
+          cp release-artifacts/thistle-os-firmware/thistle_os.bin.manifest "dist/thistle_os-${RELEASE_TAG}.bin.manifest"
+          cp release-artifacts/thistle-os-firmware/thistle_os.bin.manifest.sig "dist/thistle_os-${RELEASE_TAG}.bin.manifest.sig"
           cp release-artifacts/thistle-os-firmware/thistle_os.bin.pub "dist/thistle_os-${RELEASE_TAG}.bin.pub"
+          cp release-artifacts/thistle-os-firmware/signed-board-profiles/* dist/
           cp release-artifacts/thistle-recovery/thistle-recovery "dist/thistle-recovery-${RELEASE_TAG}"
           cd dist
           sha256sum * > SHA256SUMS

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,6 +121,13 @@ jobs:
           ! grep -q "AuthMethod::None" recovery/src/main.rs
           test "$(grep -c "authFetch('/api/" recovery/src/recovery_web.rs)" -eq 7
 
+      - name: Test canonical signed artifact manifests
+        run: |
+          rustc --edition=2021 --test recovery/src/artifact_manifest.rs \
+            -o /tmp/test_artifact_manifest
+          /tmp/test_artifact_manifest
+          grep -q "manifest_url" recovery/src/recovery_ota.rs
+
   simulator-boot:
     name: Simulator Boot Test
     runs-on: ubuntu-latest

--- a/components/kernel_rs/src/version.rs
+++ b/components/kernel_rs/src/version.rs
@@ -5,6 +5,9 @@ pub const VERSION_MAJOR: u32 = 0;
 pub const VERSION_MINOR: u32 = 5;
 pub const VERSION_PATCH: u32 = 0;
 pub const VERSION_STRING: &str = "0.5.0";
+/// Monotonic signed-release counter. Never decrease or reuse this value for a
+/// release that contains different firmware bytes.
+pub const SECURITY_VERSION: u32 = 500;
 
 /// Compare a semver requirement string against the running kernel version.
 /// Returns true if the requirement is satisfied (req <= current).
@@ -54,5 +57,10 @@ mod tests {
     fn test_satisfies_empty() {
         // An empty requirement string parses as 0.0.0 — always satisfied
         assert!(satisfies(""));
+    }
+
+    #[test]
+    fn security_version_is_nonzero() {
+        assert!(SECURITY_VERSION > 0);
     }
 }

--- a/docs/security/artifact-manifests.md
+++ b/docs/security/artifact-manifests.md
@@ -1,0 +1,44 @@
+# Signed artifact manifests
+
+Recovery installs only artifacts described by a canonical
+`THISTLE-ARTIFACT-MANIFEST-V1` manifest signed by the Recovery Ed25519 root.
+The signature binds the payload digest and size together with its type, ID,
+version, monotonic security version, architecture, compatible boards,
+destination, and download URL.
+
+Catalog entries are discovery pointers only. Each installable entry must expose
+`manifest_url` and `manifest_sig_url`; legacy `sha256`, `url`, and `sig_url`
+fields are not an authorization boundary and cannot make an artifact
+installable. Recovery rejects legacy-only entries.
+
+Generate a manifest and signature with:
+
+```console
+python3 tools/sign.py manifest path/to/payload \
+  --key private.key \
+  --type driver \
+  --id qmi8658c \
+  --version 1.0.0 \
+  --security-version 1 \
+  --arch esp32s3 \
+  --compatible-board tdeck-pro \
+  --url https://example.invalid/qmi8658c.drv.elf
+```
+
+This creates `payload.manifest` and `payload.manifest.sig`. Board, driver, and
+window-manager manifests are retained beside the active artifact. The selected
+board profile also retains manifest evidence beside `config/board.json`.
+Firmware evidence is retained as `config/firmware.manifest` and
+`config/firmware.manifest.sig` for boot-health and anti-rollback processing.
+
+## Migration
+
+1. Publish the payload, canonical manifest, and manifest signature.
+2. Add both manifest URLs to the catalog entry.
+3. Keep the legacy fields only for older clients during the transition.
+4. Confirm the signed ID, destination, chip, board list, version, and security
+   version before publishing.
+5. Never decrease or reuse a firmware security version for different bytes.
+
+Unsigned board profiles and raw payload signatures are intentionally rejected
+by the new Recovery installer.

--- a/recovery/src/artifact_manifest.rs
+++ b/recovery/src/artifact_manifest.rs
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Canonical, signed description of a Recovery-installable artifact.
+
+pub const MANIFEST_HEADER: &str = "THISTLE-ARTIFACT-MANIFEST-V1";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ArtifactType {
+    Firmware,
+    Board,
+    Driver,
+    WindowManager,
+}
+
+impl ArtifactType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Firmware => "firmware",
+            Self::Board => "board",
+            Self::Driver => "driver",
+            Self::WindowManager => "wm",
+        }
+    }
+
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "firmware" => Ok(Self::Firmware),
+            "board" => Ok(Self::Board),
+            "driver" => Ok(Self::Driver),
+            "wm" => Ok(Self::WindowManager),
+            _ => Err(format!("unsupported artifact type '{value}'")),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArtifactManifest {
+    pub artifact_type: ArtifactType,
+    pub id: String,
+    pub version: String,
+    pub security_version: u32,
+    pub arch: String,
+    pub compatible_boards: Vec<String>,
+    pub destination: String,
+    pub sha256: String,
+    pub size: usize,
+    pub url: String,
+}
+
+impl ArtifactManifest {
+    pub fn parse(canonical: &str) -> Result<Self, String> {
+        if !canonical.ends_with('\n') || canonical.contains('\r') {
+            return Err("manifest must use canonical LF-terminated lines".to_string());
+        }
+        let lines: Vec<&str> = canonical[..canonical.len() - 1].split('\n').collect();
+        if lines.len() != 11 || lines[0] != MANIFEST_HEADER {
+            return Err("manifest has an invalid header or field count".to_string());
+        }
+
+        let artifact_type = ArtifactType::parse(field(lines[1], "type")?)?;
+        let id = field(lines[2], "id")?.to_string();
+        let version = field(lines[3], "version")?.to_string();
+        let security_version = field(lines[4], "security_version")?
+            .parse::<u32>()
+            .map_err(|_| "security_version must be a decimal u32".to_string())?;
+        let arch = field(lines[5], "arch")?.to_string();
+        let compatible_boards = field(lines[6], "compatible_boards")?
+            .split(',')
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let destination = field(lines[7], "destination")?.to_string();
+        let sha256 = field(lines[8], "sha256")?.to_string();
+        let size = field(lines[9], "size")?
+            .parse::<usize>()
+            .map_err(|_| "size must be a decimal usize".to_string())?;
+        let url = field(lines[10], "url")?.to_string();
+
+        let manifest = Self {
+            artifact_type,
+            id,
+            version,
+            security_version,
+            arch,
+            compatible_boards,
+            destination,
+            sha256,
+            size,
+            url,
+        };
+        manifest.validate_shape()?;
+        if manifest.canonical_bytes() != canonical.as_bytes() {
+            return Err("manifest is not in canonical form".to_string());
+        }
+        Ok(manifest)
+    }
+
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        format!(
+            concat!(
+                "{}\n",
+                "type={}\n",
+                "id={}\n",
+                "version={}\n",
+                "security_version={}\n",
+                "arch={}\n",
+                "compatible_boards={}\n",
+                "destination={}\n",
+                "sha256={}\n",
+                "size={}\n",
+                "url={}\n"
+            ),
+            MANIFEST_HEADER,
+            self.artifact_type.as_str(),
+            self.id,
+            self.version,
+            self.security_version,
+            self.arch,
+            self.compatible_boards.join(","),
+            self.destination,
+            self.sha256,
+            self.size,
+            self.url,
+        )
+        .into_bytes()
+    }
+
+    pub fn validate_for_device(
+        &self,
+        chip: &str,
+        board: &str,
+        minimum_security_version: u32,
+    ) -> Result<(), String> {
+        self.validate_shape()?;
+        if self.arch != chip {
+            return Err(format!(
+                "artifact architecture '{}' does not match '{}'",
+                self.arch, chip
+            ));
+        }
+        if self.security_version < minimum_security_version {
+            return Err(format!(
+                "artifact security version {} is below device minimum {}",
+                self.security_version, minimum_security_version
+            ));
+        }
+        if !self
+            .compatible_boards
+            .iter()
+            .any(|candidate| candidate == board)
+        {
+            return Err(format!("artifact is not signed for board '{board}'"));
+        }
+        if self.artifact_type == ArtifactType::Board && self.id != board {
+            return Err("board manifest identity does not match selection".to_string());
+        }
+        Ok(())
+    }
+
+    fn validate_shape(&self) -> Result<(), String> {
+        validate_identifier(&self.id, "id")?;
+        validate_version(&self.version)?;
+        if self.security_version == 0 {
+            return Err("security_version must be greater than zero".to_string());
+        }
+        if !matches!(
+            self.arch.as_str(),
+            "esp32" | "esp32s2" | "esp32s3" | "esp32c3" | "esp32c6" | "esp32h2"
+        ) {
+            return Err(format!("unsupported architecture '{}'", self.arch));
+        }
+        if self.compatible_boards.is_empty() {
+            return Err("compatible_boards must not be empty".to_string());
+        }
+        let mut previous: Option<&str> = None;
+        for board in &self.compatible_boards {
+            validate_identifier(board, "compatible board")?;
+            if previous.is_some_and(|value| value >= board.as_str()) {
+                return Err("compatible_boards must be sorted and unique".to_string());
+            }
+            previous = Some(board);
+        }
+        let expected_destination = expected_destination(self.artifact_type, &self.id);
+        if self.destination != expected_destination {
+            return Err(format!(
+                "destination '{}' does not match signed artifact role '{}'",
+                self.destination, expected_destination
+            ));
+        }
+        if self.sha256.len() != 64
+            || !self
+                .sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        {
+            return Err("sha256 must be 64 lowercase hexadecimal characters".to_string());
+        }
+        if self.size == 0 {
+            return Err("artifact size must be greater than zero".to_string());
+        }
+        if !self.url.starts_with("https://") || self.url.bytes().any(|byte| byte <= b' ') {
+            return Err("artifact URL must be a whitespace-free HTTPS URL".to_string());
+        }
+        Ok(())
+    }
+}
+
+pub fn expected_destination(artifact_type: ArtifactType, id: &str) -> String {
+    match artifact_type {
+        ArtifactType::Firmware => "ota_1".to_string(),
+        ArtifactType::Board => format!("config/boards/{id}.json"),
+        ArtifactType::Driver => format!("drivers/{id}.drv.elf"),
+        ArtifactType::WindowManager => format!("wm/{id}.wm.elf"),
+    }
+}
+
+fn field<'a>(line: &'a str, expected_name: &str) -> Result<&'a str, String> {
+    line.strip_prefix(expected_name)
+        .and_then(|rest| rest.strip_prefix('='))
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| format!("missing or empty canonical field '{expected_name}'"))
+}
+
+fn validate_identifier(value: &str, label: &str) -> Result<(), String> {
+    if value.is_empty()
+        || value.len() > 64
+        || value.starts_with('.')
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        return Err(format!("invalid {label} '{value}'"));
+    }
+    Ok(())
+}
+
+fn validate_version(version: &str) -> Result<(), String> {
+    let normalized = version.strip_prefix('v').unwrap_or(version);
+    let parts: Vec<&str> = normalized.split('.').collect();
+    if parts.len() != 3
+        || parts
+            .iter()
+            .any(|part| part.is_empty() || !part.bytes().all(|byte| byte.is_ascii_digit()))
+    {
+        return Err(format!(
+            "version '{version}' must be a numeric semantic version"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn firmware() -> ArtifactManifest {
+        ArtifactManifest {
+            artifact_type: ArtifactType::Firmware,
+            id: "thistle-os".to_string(),
+            version: "v0.5.1".to_string(),
+            security_version: 12,
+            arch: "esp32s3".to_string(),
+            compatible_boards: vec!["tdeck".to_string(), "tdeck-pro".to_string()],
+            destination: "ota_1".to_string(),
+            sha256: "ab".repeat(32),
+            size: 1_048_576,
+            url: "https://downloads.example/thistle-os.bin".to_string(),
+        }
+    }
+
+    #[test]
+    fn canonical_manifest_round_trips() {
+        let manifest = firmware();
+        let bytes = manifest.canonical_bytes();
+        assert_eq!(
+            ArtifactManifest::parse(std::str::from_utf8(&bytes).unwrap()),
+            Ok(manifest)
+        );
+    }
+
+    #[test]
+    fn metadata_changes_change_signed_bytes() {
+        let original = firmware();
+        for changed in [
+            ArtifactManifest {
+                artifact_type: ArtifactType::Driver,
+                destination: "drivers/thistle-os.drv.elf".to_string(),
+                ..original.clone()
+            },
+            ArtifactManifest {
+                id: "other".to_string(),
+                ..original.clone()
+            },
+            ArtifactManifest {
+                version: "v0.5.0".to_string(),
+                ..original.clone()
+            },
+            ArtifactManifest {
+                security_version: 11,
+                ..original.clone()
+            },
+            ArtifactManifest {
+                arch: "esp32c3".to_string(),
+                ..original.clone()
+            },
+            ArtifactManifest {
+                compatible_boards: vec!["tdeck".to_string()],
+                ..original.clone()
+            },
+            ArtifactManifest {
+                sha256: "cd".repeat(32),
+                ..original.clone()
+            },
+            ArtifactManifest {
+                size: original.size + 1,
+                ..original.clone()
+            },
+            ArtifactManifest {
+                url: "https://downloads.example/other.bin".to_string(),
+                ..original.clone()
+            },
+        ] {
+            assert_ne!(changed.canonical_bytes(), original.canonical_bytes());
+        }
+    }
+
+    #[test]
+    fn device_policy_rejects_relabeling_incompatibility_and_rollback() {
+        let manifest = firmware();
+        assert!(manifest
+            .validate_for_device("esp32s3", "tdeck-pro", 12)
+            .is_ok());
+        assert!(manifest
+            .validate_for_device("esp32c3", "tdeck-pro", 12)
+            .is_err());
+        assert!(manifest
+            .validate_for_device("esp32s3", "c3-mini", 12)
+            .is_err());
+        assert!(manifest
+            .validate_for_device("esp32s3", "tdeck-pro", 13)
+            .is_err());
+
+        let board = ArtifactManifest {
+            artifact_type: ArtifactType::Board,
+            id: "tdeck".to_string(),
+            version: "1.0.0".to_string(),
+            security_version: 1,
+            arch: "esp32s3".to_string(),
+            compatible_boards: vec!["tdeck".to_string()],
+            destination: "config/boards/tdeck.json".to_string(),
+            sha256: "ef".repeat(32),
+            size: 1024,
+            url: "https://downloads.example/tdeck.json".to_string(),
+        };
+        assert!(board
+            .validate_for_device("esp32s3", "tdeck-pro", 1)
+            .is_err());
+    }
+
+    #[test]
+    fn malformed_or_noncanonical_manifests_fail_closed() {
+        let canonical = String::from_utf8(firmware().canonical_bytes()).unwrap();
+        assert!(ArtifactManifest::parse(
+            &canonical.replace("destination=ota_1", "destination=drivers/x.drv.elf")
+        )
+        .is_err());
+        assert!(ArtifactManifest::parse(&canonical.replace(
+            "compatible_boards=tdeck,tdeck-pro",
+            "compatible_boards=tdeck-pro,tdeck"
+        ))
+        .is_err());
+        assert!(ArtifactManifest::parse(&canonical.replace("sha256=", "sha256=AB")).is_err());
+        assert!(ArtifactManifest::parse(canonical.trim_end()).is_err());
+        assert!(ArtifactManifest::parse(&(canonical.clone() + "extra=x\n")).is_err());
+    }
+}

--- a/recovery/src/main.rs
+++ b/recovery/src/main.rs
@@ -22,6 +22,7 @@ use esp_idf_svc::wifi::{
 
 use log::*;
 
+mod artifact_manifest;
 mod bounded_io;
 mod bundle_transaction;
 mod catalog_path;

--- a/recovery/src/recovery_ota.rs
+++ b/recovery/src/recovery_ota.rs
@@ -10,9 +10,10 @@ use std::io::{self, Read, Seek, Write};
 use std::path::Path;
 use std::sync::atomic::{AtomicU8, Ordering};
 
+use crate::artifact_manifest::{ArtifactManifest, ArtifactType};
 use crate::bounded_io;
 use crate::bundle_transaction::{self, Boundary, BundleFile, RecoveryAction};
-use crate::catalog_path::{catalog_destination, validate_catalog_id};
+use crate::catalog_path::validate_catalog_id;
 
 // ---------------------------------------------------------------------------
 // Chip detection
@@ -89,6 +90,7 @@ const MAX_CATALOG_SIZE: usize = 256 * 1024;
 const MAX_BOARD_PROFILE_SIZE: usize = 64 * 1024;
 const MAX_EXECUTABLE_SIZE: usize = 2 * 1024 * 1024;
 const MAX_SIGNATURE_SIZE: usize = 64;
+const MAX_ARTIFACT_MANIFEST_SIZE: usize = 4096;
 const REQUIRE_EXECUTABLE_SIGNATURES: bool = true;
 
 #[cfg(not(debug_assertions))]
@@ -1201,6 +1203,92 @@ pub fn recovery_download_board_bundle(catalog_url: &str) -> anyhow::Result<u32> 
     recovery_download_board_bundle_for(catalog_url, &board_name)
 }
 
+struct VerifiedManifest {
+    manifest: ArtifactManifest,
+    canonical: Vec<u8>,
+    signature: Vec<u8>,
+}
+
+fn fetch_verified_manifests(catalog_json: &str) -> anyhow::Result<Vec<VerifiedManifest>> {
+    let mut manifests = Vec::new();
+    for obj in iter_json_objects(catalog_json) {
+        let Some(legacy_type) = json_extract_string(obj, "type") else {
+            continue;
+        };
+        if !matches!(legacy_type.as_str(), "firmware" | "board" | "driver" | "wm") {
+            continue;
+        }
+        let manifest_url = json_extract_string(obj, "manifest_url").ok_or_else(|| {
+            anyhow::anyhow!("Catalog {} entry is missing manifest_url", legacy_type)
+        })?;
+        let signature_url = json_extract_string(obj, "manifest_sig_url").ok_or_else(|| {
+            anyhow::anyhow!("Catalog {} entry is missing manifest_sig_url", legacy_type)
+        })?;
+        let canonical = http_get_bytes(&manifest_url, MAX_ARTIFACT_MANIFEST_SIZE)?;
+        let signature = http_get_bytes(&signature_url, MAX_SIGNATURE_SIZE)?;
+        let mut reader = std::io::Cursor::new(&canonical);
+        verify_ed25519_reader(&mut reader, &signature)?;
+        let text = std::str::from_utf8(&canonical)
+            .map_err(|_| anyhow::anyhow!("Signed artifact manifest is not UTF-8"))?;
+        let manifest = ArtifactManifest::parse(text).map_err(anyhow::Error::msg)?;
+
+        if manifest.artifact_type.as_str() != legacy_type {
+            anyhow::bail!(
+                "Catalog type '{}' disagrees with signed type '{}'",
+                legacy_type,
+                manifest.artifact_type.as_str()
+            );
+        }
+        if let Some(legacy_id) = json_extract_string(obj, "id") {
+            if legacy_id != manifest.id {
+                anyhow::bail!(
+                    "Catalog id '{}' disagrees with signed id '{}'",
+                    legacy_id,
+                    manifest.id
+                );
+            }
+        }
+        manifests.push(VerifiedManifest {
+            manifest,
+            canonical,
+            signature,
+        });
+    }
+    Ok(manifests)
+}
+
+fn artifact_size_limit(artifact_type: ArtifactType) -> usize {
+    match artifact_type {
+        ArtifactType::Firmware => MAX_FIRMWARE_SIZE,
+        ArtifactType::Board => MAX_BOARD_PROFILE_SIZE,
+        ArtifactType::Driver | ArtifactType::WindowManager => MAX_EXECUTABLE_SIZE,
+    }
+}
+
+fn download_verified_payload(
+    artifact: &ArtifactManifest,
+    destination: &Path,
+) -> anyhow::Result<()> {
+    let limit = artifact_size_limit(artifact.artifact_type);
+    if artifact.size > limit {
+        anyhow::bail!(
+            "Signed {} artifact '{}' exceeds its {} byte limit",
+            artifact.artifact_type.as_str(),
+            artifact.id,
+            limit
+        );
+    }
+    let written = http_get_to_file(&artifact.url, artifact.size, destination)?;
+    if written != artifact.size {
+        anyhow::bail!(
+            "Signed artifact size mismatch: expected {}, received {}",
+            artifact.size,
+            written
+        );
+    }
+    verify_sha256_file(destination, &artifact.sha256)
+}
+
 /// Download all drivers, board config, WM entries, and the firmware image that are
 /// compatible with `board_name`.
 ///
@@ -1229,42 +1317,47 @@ pub fn recovery_download_board_bundle_for(
     info!("Fetching catalog: {}", catalog_url);
     let catalog_json = http_get_string(catalog_url, MAX_CATALOG_SIZE)?;
 
-    // Detect the running chip once so arch filtering can be applied to every entry.
     let chip = detect_chip();
-    info!("Filtering catalog for chip: {}", chip);
-
-    // Closure: decide whether a catalog entry JSON object should be downloaded.
-    // The selected board config is authoritative; hardware probes are optional
-    // presentation hints and are not used for install decisions.
-    let entry_should_download = |obj: &str| -> bool {
-        // Arch check first — skip entries targeting a different chip entirely.
-        if !catalog_entry_arch_matches(obj, chip) {
-            return false;
+    info!("Verifying signed manifests for chip: {}", chip);
+    let verified_manifests = fetch_verified_manifests(&catalog_json)?;
+    let mut selected = Vec::new();
+    for artifact in verified_manifests {
+        if artifact.manifest.arch != chip
+            || !artifact
+                .manifest
+                .compatible_boards
+                .iter()
+                .any(|candidate| candidate == board_name)
+            || (artifact.manifest.artifact_type == ArtifactType::Board
+                && artifact.manifest.id != board_name)
+        {
+            continue;
         }
+        artifact
+            .manifest
+            .validate_for_device(chip, board_name, 1)
+            .map_err(anyhow::Error::msg)?;
+        selected.push(artifact);
+    }
 
-        let entry_type = json_extract_string(obj, "type").unwrap_or_default();
-        match entry_type.as_str() {
-            "driver" | "firmware" | "wm" => catalog_entry_board_matches(obj, board_name),
-            "board" => {
-                let id = json_extract_string(obj, "board_id")
-                    .or_else(|| json_extract_string(obj, "id"))
-                    .unwrap_or_default();
-                id == board_name
-            }
-            _ => false,
-        }
-    };
-
-    // First pass: count compatible entries so we can report accurate progress.
-    let total_entries: u32 = iter_json_objects(&catalog_json)
-        .filter(|obj| entry_should_download(obj))
-        .count() as u32;
-
-    if total_entries == 0 {
+    if selected.is_empty() {
         anyhow::bail!(
-            "Catalog has no compatible bundle entries for '{}'",
+            "Catalog has no signed compatible bundle entries for '{}'",
             board_name
         );
+    }
+
+    let total_entries = u32::try_from(selected.len())?;
+    let firmware_count = selected
+        .iter()
+        .filter(|artifact| artifact.manifest.artifact_type == ArtifactType::Firmware)
+        .count();
+    let board_count = selected
+        .iter()
+        .filter(|artifact| artifact.manifest.artifact_type == ArtifactType::Board)
+        .count();
+    if firmware_count != 1 || board_count != 1 {
+        anyhow::bail!("Signed bundle must contain exactly one firmware and one board profile");
     }
 
     let mut downloaded = 0u32;
@@ -1272,93 +1365,81 @@ pub fn recovery_download_board_bundle_for(
     let mut bundle_files = Vec::new();
     let mut firmware_path: Option<std::path::PathBuf> = None;
 
-    for obj in iter_json_objects(&catalog_json) {
-        if !entry_should_download(obj) {
-            continue;
+    let mut destinations = std::collections::BTreeSet::new();
+    for artifact in selected {
+        let manifest = &artifact.manifest;
+        if !destinations.insert(manifest.destination.clone()) {
+            anyhow::bail!(
+                "Signed bundle contains duplicate destination '{}'",
+                manifest.destination
+            );
         }
+        validate_catalog_id(&manifest.id).map_err(anyhow::Error::msg)?;
 
-        let entry_type = json_extract_string(obj, "type").unwrap_or_default();
-        let id = match json_extract_string(obj, "id") {
-            Some(v) => v,
-            None => anyhow::bail!("Compatible catalog entry is missing id"),
-        };
-        validate_catalog_id(&id).map_err(anyhow::Error::msg)?;
-        let url = match json_extract_string(obj, "url") {
-            Some(v) => v,
-            None => anyhow::bail!("Compatible catalog entry '{}' is missing url", id),
-        };
-        let sig_url = json_extract_string(obj, "sig_url");
-        let expected_sha = json_extract_string(obj, "sha256");
-        let name = json_extract_string(obj, "name").unwrap_or_else(|| id.clone());
-
-        let dest_path = match entry_type.as_str() {
-            "firmware" => Ok(std::path::PathBuf::new()),
-            "board" => catalog_destination(SD_BOARDS_DIR, &id, ".json"),
-            "driver" => catalog_destination(SD_DRIVERS_DIR, &id, ".drv.elf"),
-            "wm" => catalog_destination(SD_WM_DIR, &id, ".wm.elf"),
-            other => {
-                info!("Skipping '{}' (type={})", id, other);
-                continue;
-            }
-        }
-        .map_err(anyhow::Error::msg)?
-        .to_string_lossy()
-        .into_owned();
-
-        if entry_type == "firmware" {
-            let Some(expected_sha) = expected_sha.as_deref().filter(|s| !s.is_empty()) else {
-                anyhow::bail!("Firmware '{}' is missing sha256", name);
-            };
+        if manifest.artifact_type == ArtifactType::Firmware {
             if firmware_path.is_some() {
-                anyhow::bail!("Catalog contains multiple compatible firmware images");
+                anyhow::bail!("Signed bundle contains multiple firmware images");
             }
-            info!("Downloading and verifying firmware {}", name);
-            println!("  {} [firmware, staged on SD]", name);
+            info!("Downloading signed firmware {}", manifest.id);
+            println!("  {} [firmware, staged on SD]", manifest.id);
             let staged = download_stage.path(&format!("{}-firmware.bin", downloaded))?;
-            download_catalog_entry_to_file(
-                &url,
-                Some(expected_sha),
-                sig_url.as_deref(),
-                REQUIRE_EXECUTABLE_SIGNATURES,
-                MAX_FIRMWARE_SIZE,
-                &staged,
+            download_verified_payload(manifest, &staged)?;
+            let staged_manifest =
+                download_stage.write(&format!("{}-manifest", downloaded), &artifact.canonical)?;
+            let staged_signature = download_stage.write(
+                &format!("{}-manifest-signature", downloaded),
+                &artifact.signature,
             )?;
+            bundle_files.push(BundleFile::from_file(
+                "config/firmware.manifest",
+                staged_manifest,
+            )?);
+            bundle_files.push(BundleFile::from_file(
+                "config/firmware.manifest.sig",
+                staged_signature,
+            )?);
             firmware_path = Some(staged);
         } else {
-            info!("Downloading and verifying {} -> {}", name, dest_path);
-            println!("  {} [{}]", name, entry_type);
-            let require_signature =
-                matches!(entry_type.as_str(), "driver" | "wm") && REQUIRE_EXECUTABLE_SIGNATURES;
+            info!(
+                "Downloading signed {} -> {}",
+                manifest.id, manifest.destination
+            );
+            println!("  {} [{}]", manifest.id, manifest.artifact_type.as_str());
             let staged = download_stage.path(&format!("{}-payload", downloaded))?;
-            let max_size = if entry_type == "board" {
-                MAX_BOARD_PROFILE_SIZE
-            } else {
-                MAX_EXECUTABLE_SIZE
-            };
-            let signature = download_catalog_entry_to_file(
-                &url,
-                expected_sha.as_deref(),
-                sig_url.as_deref(),
-                require_signature,
-                max_size,
-                &staged,
-            )?;
-            let relative = sdcard_relative_path(&dest_path)?;
-            if entry_type == "board" {
+            download_verified_payload(manifest, &staged)?;
+            let relative = std::path::PathBuf::from(&manifest.destination);
+            if manifest.artifact_type == ArtifactType::Board {
                 bundle_files.push(BundleFile::from_file("config/board.json", &staged)?);
             }
             bundle_files.push(BundleFile::from_file(&relative, &staged)?);
-            if let Some(signature) = signature {
-                let signature_path = format!("{}.sig", relative.to_string_lossy());
-                let staged_signature =
-                    download_stage.write(&format!("{}-signature", downloaded), &signature)?;
-                bundle_files.push(BundleFile::from_file(signature_path, staged_signature)?);
-                info!("Signature downloaded for '{}'", name);
+            let staged_manifest =
+                download_stage.write(&format!("{}-manifest", downloaded), &artifact.canonical)?;
+            let staged_signature = download_stage.write(
+                &format!("{}-manifest-signature", downloaded),
+                &artifact.signature,
+            )?;
+            bundle_files.push(BundleFile::from_file(
+                format!("{}.manifest", relative.to_string_lossy()),
+                &staged_manifest,
+            )?);
+            bundle_files.push(BundleFile::from_file(
+                format!("{}.manifest.sig", relative.to_string_lossy()),
+                &staged_signature,
+            )?);
+            if manifest.artifact_type == ArtifactType::Board {
+                bundle_files.push(BundleFile::from_file(
+                    "config/board.json.manifest",
+                    staged_manifest,
+                )?);
+                bundle_files.push(BundleFile::from_file(
+                    "config/board.json.manifest.sig",
+                    staged_signature,
+                )?);
             }
         }
 
         downloaded += 1;
-        info!("Verified '{}'", name);
+        info!("Verified signed artifact '{}'", manifest.id);
 
         // Update progress
         if total_entries > 0 {
@@ -1491,32 +1572,26 @@ pub fn recovery_bundle_plan_json(catalog_url: &str, board_name: &str) -> anyhow:
     let chip = detect_chip();
     let mut entries: Vec<String> = Vec::new();
 
-    for obj in iter_json_objects(&catalog_json) {
-        if !catalog_entry_arch_matches(obj, chip) {
+    for artifact in fetch_verified_manifests(&catalog_json)? {
+        let manifest = artifact.manifest;
+        if manifest.arch != chip
+            || !manifest
+                .compatible_boards
+                .iter()
+                .any(|candidate| candidate == board_name)
+            || (manifest.artifact_type == ArtifactType::Board && manifest.id != board_name)
+        {
             continue;
         }
-
-        let entry_type = json_extract_string(obj, "type").unwrap_or_default();
-        let matches = match entry_type.as_str() {
-            "driver" | "firmware" | "wm" => catalog_entry_board_matches(obj, board_name),
-            "board" => {
-                let id = json_extract_string(obj, "board_id")
-                    .or_else(|| json_extract_string(obj, "id"))
-                    .unwrap_or_default();
-                id == board_name
-            }
-            _ => false,
-        };
-
-        if !matches {
-            continue;
-        }
-
-        let id = json_extract_string(obj, "id").unwrap_or_default();
-        let name = json_extract_string(obj, "name").unwrap_or_else(|| id.clone());
+        manifest
+            .validate_for_device(chip, board_name, 1)
+            .map_err(anyhow::Error::msg)?;
         entries.push(format!(
-            r#"{{"id":"{}","type":"{}","name":"{}"}}"#,
-            id, entry_type, name
+            r#"{{"id":"{}","type":"{}","version":"{}","destination":"{}"}}"#,
+            manifest.id,
+            manifest.artifact_type.as_str(),
+            manifest.version,
+            manifest.destination,
         ));
     }
 

--- a/tools/sign.py
+++ b/tools/sign.py
@@ -2,6 +2,7 @@
 """ThistleOS Ed25519 signing tool for apps, drivers, and firmware."""
 
 import argparse
+import hashlib
 import os
 from pathlib import Path
 import sys
@@ -15,6 +16,7 @@ from cryptography.exceptions import InvalidSignature
 
 PRIVATE_KEY_PATH = Path("private.key")
 PUBLIC_KEY_PATH = Path("public.key")
+MANIFEST_HEADER = "THISTLE-ARTIFACT-MANIFEST-V1"
 
 
 def _require_absent(path):
@@ -97,6 +99,64 @@ def cmd_verify(args):
         sys.exit(1)
 
 
+def manifest_destination(artifact_type, artifact_id):
+    destinations = {
+        "firmware": "ota_1",
+        "board": f"config/boards/{artifact_id}.json",
+        "driver": f"drivers/{artifact_id}.drv.elf",
+        "wm": f"wm/{artifact_id}.wm.elf",
+    }
+    return destinations[artifact_type]
+
+
+def canonical_manifest(*, artifact_type, artifact_id, version, security_version,
+                       arch, compatible_boards, url, payload):
+    boards = sorted(set(compatible_boards))
+    if not boards:
+        raise ValueError("at least one compatible board is required")
+    fields = [artifact_id, version, arch, url, *boards]
+    if any(not value or "\n" in value or "\r" in value for value in fields):
+        raise ValueError("manifest fields must be non-empty single-line values")
+    digest = hashlib.sha256(payload).hexdigest()
+    return (
+        f"{MANIFEST_HEADER}\n"
+        f"type={artifact_type}\n"
+        f"id={artifact_id}\n"
+        f"version={version}\n"
+        f"security_version={security_version}\n"
+        f"arch={arch}\n"
+        f"compatible_boards={','.join(boards)}\n"
+        f"destination={manifest_destination(artifact_type, artifact_id)}\n"
+        f"sha256={digest}\n"
+        f"size={len(payload)}\n"
+        f"url={url}\n"
+    ).encode("utf-8")
+
+
+def cmd_manifest(args):
+    seed = Path(args.key).read_bytes()
+    if len(seed) != 32:
+        raise ValueError(f"private key must be 32 bytes, got {len(seed)}")
+    payload_path = Path(args.file)
+    canonical = canonical_manifest(
+        artifact_type=args.type,
+        artifact_id=args.id,
+        version=args.version,
+        security_version=args.security_version,
+        arch=args.arch,
+        compatible_boards=args.compatible_board,
+        url=args.url,
+        payload=payload_path.read_bytes(),
+    )
+    signature = Ed25519PrivateKey.from_private_bytes(seed).sign(canonical)
+    manifest_path = Path(f"{args.file}.manifest")
+    signature_path = Path(f"{args.file}.manifest.sig")
+    _write_new_file(manifest_path, canonical, 0o644)
+    _write_new_file(signature_path, signature, 0o644)
+    print(f"Manifest written to: {manifest_path}")
+    print(f"Manifest signature written to: {signature_path}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="ThistleOS Ed25519 signing tool"
@@ -118,6 +178,27 @@ def main():
     verify_parser.add_argument("--pubkey", required=True, metavar="public.key",
                                help="Path to public key (raw 32 bytes)")
 
+    manifest_parser = subparsers.add_parser(
+        "manifest", help="Create and sign a canonical artifact manifest"
+    )
+    manifest_parser.add_argument("file", help="Artifact payload")
+    manifest_parser.add_argument("--key", required=True, help="Raw 32-byte private key")
+    manifest_parser.add_argument(
+        "--type", required=True, choices=["firmware", "board", "driver", "wm"]
+    )
+    manifest_parser.add_argument("--id", required=True)
+    manifest_parser.add_argument("--version", required=True)
+    manifest_parser.add_argument("--security-version", required=True, type=int)
+    manifest_parser.add_argument(
+        "--arch", required=True,
+        choices=["esp32", "esp32s2", "esp32s3", "esp32c3", "esp32c6", "esp32h2"],
+    )
+    manifest_parser.add_argument(
+        "--compatible-board", required=True, action="append",
+        help="Signed compatible board ID; repeat for multiple boards",
+    )
+    manifest_parser.add_argument("--url", required=True)
+
     args = parser.parse_args()
 
     try:
@@ -127,7 +208,9 @@ def main():
             cmd_sign(args)
         elif args.command == "verify":
             cmd_verify(args)
-    except OSError as error:
+        elif args.command == "manifest":
+            cmd_manifest(args)
+    except (OSError, ValueError) as error:
         print(f"ERROR: {error}", file=sys.stderr)
         sys.exit(1)
 

--- a/tools/test_sign.py
+++ b/tools/test_sign.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import stat
 import subprocess
 import tempfile
+from types import SimpleNamespace
 import unittest
 
 import sign
@@ -86,6 +87,83 @@ class KeyGenerationSecurityTests(unittest.TestCase):
             check=False,
         )
         self.assertEqual(result.returncode, 0)
+
+
+class ArtifactManifestTests(unittest.TestCase):
+    def test_manifest_signature_binds_every_security_field(self):
+        private_key = sign.Ed25519PrivateKey.generate()
+        payload = b"firmware bytes"
+        fields = {
+            "artifact_type": "firmware",
+            "artifact_id": "thistle-os",
+            "version": "0.5.0",
+            "security_version": 500,
+            "arch": "esp32s3",
+            "compatible_boards": ["tdeck-pro", "tdeck"],
+            "url": "https://downloads.example/thistle-os.bin",
+            "payload": payload,
+        }
+        canonical = sign.canonical_manifest(**fields)
+        signature = private_key.sign(canonical)
+        private_key.public_key().verify(signature, canonical)
+
+        mutations = {
+            "artifact_type": "driver",
+            "artifact_id": "other",
+            "version": "0.4.0",
+            "security_version": 499,
+            "arch": "esp32c3",
+            "compatible_boards": ["c3-mini"],
+            "url": "https://downloads.example/other.bin",
+            "payload": b"other bytes",
+        }
+        for field, value in mutations.items():
+            changed = dict(fields)
+            changed[field] = value
+            with self.subTest(field=field), self.assertRaises(sign.InvalidSignature):
+                private_key.public_key().verify(
+                    signature, sign.canonical_manifest(**changed)
+                )
+
+    def test_manifest_generation_is_deterministic_and_sorts_boards(self):
+        arguments = {
+            "artifact_type": "board",
+            "artifact_id": "tdeck-pro",
+            "version": "1.0.0",
+            "security_version": 1,
+            "arch": "esp32s3",
+            "compatible_boards": ["tdeck-pro", "tdeck", "tdeck-pro"],
+            "url": "https://downloads.example/tdeck-pro.json",
+            "payload": b"{}",
+        }
+        first = sign.canonical_manifest(**arguments)
+        second = sign.canonical_manifest(**arguments)
+        self.assertEqual(first, second)
+        self.assertIn(b"compatible_boards=tdeck,tdeck-pro\n", first)
+        self.assertIn(b"destination=config/boards/tdeck-pro.json\n", first)
+
+    def test_manifest_command_writes_verifiable_sidecars(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            key = sign.Ed25519PrivateKey.generate()
+            key_path = root / "private.key"
+            payload_path = root / "driver.elf"
+            key_path.write_bytes(key.private_bytes_raw())
+            payload_path.write_bytes(b"driver bytes")
+            sign.cmd_manifest(SimpleNamespace(
+                key=str(key_path),
+                file=str(payload_path),
+                type="driver",
+                id="qmi8658c",
+                version="1.0.0",
+                security_version=1,
+                arch="esp32s3",
+                compatible_board=["tdeck-pro"],
+                url="https://downloads.example/qmi8658c.drv.elf",
+            ))
+            manifest = Path(f"{payload_path}.manifest").read_bytes()
+            signature = Path(f"{payload_path}.manifest.sig").read_bytes()
+            key.public_key().verify(signature, manifest)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- define and verify a canonical signed artifact manifest that binds type, identity, version, architecture, compatible boards, destination, digest, size, and download URL
- make Recovery fail closed unless catalog entries provide signed-manifest URLs, then select and install exclusively from verified manifest fields
- retain signed manifest evidence and publish signed firmware and board-profile manifests in CI/release assets
- document the catalog migration and add regression coverage for relabeling, incompatibility, malformed manifests, and signing-tool behavior

Closes #43
Closes #66

## Security boundary
This PR intentionally does not close #65. The manifest carries `security_version` and enforces a supplied floor, but persisting and atomically advancing the device anti-rollback counter remains separate work.

The catalog migration is fail closed: entries must publish `manifest_url` and `manifest_sig_url`; legacy payload-only entries are rejected. The external catalog must be updated with the signed assets produced by this repository before installation resumes.

## Validation
- Recovery artifact-manifest host tests: 4 passed
- signing-tool tests: 8 passed
- Recovery `cargo +esp check`: passed
- Recovery optimized release build: passed (1.6 MB)
- kernel host tests: 1,318 passed
- workflow YAML parse, Rust formatting, and patch integrity: passed