### PR TITLE
Enforce Recovery anti-rollback and descope ESP32-H2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,6 +128,14 @@ jobs:
           /tmp/test_artifact_manifest
           grep -q "manifest_url" recovery/src/recovery_ota.rs
 
+      - name: Test Recovery firmware anti-rollback
+        run: |
+          rustc --edition=2021 --test recovery/src/anti_rollback.rs \
+            -o /tmp/test_anti_rollback
+          /tmp/test_anti_rollback
+          grep -q "advance_security_version_and_select" recovery/src/recovery_ota.rs
+          grep -q "EspDefaultNvsPartition::take_with(false)" recovery/src/main.rs
+
   simulator-boot:
     name: Simulator Boot Test
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # ThistleOS Development Guide
 
 ## Project Overview
-ThistleOS is a portable ESP32 family operating system with an immutable kernel, loadable drivers and apps, swappable window managers, and Ed25519 signing at every level. Supports multiple boards across ESP32, S2, S3, C3, C6, and H2 architectures. Targets LilyGo T-Deck Pro (e-paper), T-Deck (LCD), T-Display-S3, T3-S3, CYD, and C3-Mini.
+ThistleOS is a portable ESP32 family operating system with an immutable kernel, loadable drivers and apps, swappable window managers, and Ed25519 signing at every level. Supports multiple boards across ESP32, S2, S3, C3, and C6 architectures. Targets LilyGo T-Deck Pro (e-paper), T-Deck (LCD), T-Display-S3, T3-S3, CYD, and C3-Mini.
 
 ## Build System
 - **Firmware**: ESP-IDF v5.5 with CMake. `idf.py build`, `idf.py flash monitor`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # ThistleOS Development Guide
 
 ## Project Overview
-ThistleOS is a portable ESP32 family operating system with an immutable kernel, loadable drivers and apps, swappable window managers, and Ed25519 signing at every level. Supports multiple boards across ESP32, S2, S3, C3, C6, and H2 architectures. Targets LilyGo T-Deck Pro (e-paper), T-Deck (LCD), T-Display-S3, T3-S3, CYD, and C3-Mini.
+ThistleOS is a portable ESP32 family operating system with an immutable kernel, loadable drivers and apps, swappable window managers, and Ed25519 signing at every level. Supports multiple boards across ESP32, S2, S3, C3, and C6 architectures. Targets LilyGo T-Deck Pro (e-paper), T-Deck (LCD), T-Display-S3, T3-S3, CYD, and C3-Mini.
 
 ## Build System
 - **Firmware**: ESP-IDF v5.5 with CMake. `idf.py build`, `idf.py flash monitor`

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
 
 ---
 
-> **Beta Software** — Rust migration complete. 100% Rust kernel (57 modules, 51,000+ LOC, 1231 tests), 15 Rust hardware drivers, multi-board support (10 boards), and multi-arch builds (ESP32, S2, S3, C3, C6, H2). Recovery auto-detects hardware via I2C/SPI/UART scanning.
+> **Beta Software** — Rust migration complete. 100% Rust kernel (57 modules, 51,000+ LOC, 1231 tests), 15 Rust hardware drivers, multi-board support (10 boards), and multi-arch builds (ESP32, S2, S3, C3, C6). Recovery auto-detects hardware via I2C/SPI/UART scanning.
 
 ## Why ThistleOS
 
 The ESP32 ecosystem is full of great hardware — T-Deck, T-Beam, M5Stack, Heltec, custom boards — but every project starts from scratch. Different pin assignments, different displays, different radios, all requiring custom firmware.
 
-ThistleOS separates the **kernel** from the **hardware**. The kernel runs the same on every ESP32 device — ESP32, S2, S3, C3, C6, H2. Drivers are loaded at boot from the SD card. Apps are downloaded from an online store. Update your OS by dropping a file on the SD card or tapping "Update" in Settings.
+ThistleOS separates the **kernel** from the **hardware**. The kernel runs across the supported ESP32 families — ESP32, S2, S3, C3, and C6. Drivers are loaded at boot from the SD card. Apps are downloaded from an online store. Update your OS by dropping a file on the SD card or tapping "Update" in Settings.
 
 **The goal:** Flash ThistleOS once. The device figures out the rest.
 
@@ -61,7 +61,7 @@ ThistleOS separates the **kernel** from the **hardware**. The kernel runs the sa
 ├─────────────────────────────────────────────┤
 │         ESP-IDF + FreeRTOS + Hardware      │
 │  ESP32 • ESP32-S2 • ESP32-S3 (Xtensa)     │
-│  ESP32-C3 • ESP32-C6 • ESP32-H2 (RISC-V) │
+│       ESP32-C3 • ESP32-C6 (RISC-V)        │
 └─────────────────────────────────────────────┘
 ```
 
@@ -167,7 +167,7 @@ See the full [Supported Devices](https://wan0net.github.io/esp32-os/docs/devices
 | CYD ESP32-2432S028 | ESP32 | ILI9341 LCD (320×240) | Supported |
 | ESP32-C3 SuperMini | ESP32-C3 | SSD1306 OLED (128×64) | Supported |
 
-Multi-arch: ESP32 (Xtensa), ESP32-S2/S3 (Xtensa LX7), ESP32-C3/C6/H2 (RISC-V). One firmware binary per architecture. Hardware drivers auto-detected and downloaded by Recovery OS.
+Multi-arch: ESP32 (Xtensa), ESP32-S2/S3 (Xtensa LX7), ESP32-C3/C6 (RISC-V). One firmware binary per architecture. Hardware drivers auto-detected and downloaded by Recovery OS.
 
 ### LilyGo T-Deck Pro (primary target)
 
@@ -402,7 +402,7 @@ cmake .. && make -j8 && ./thistle_sim
 | Built-in apps | 14 |
 | HAL interfaces | 11 (display, input, radio, GPS, audio, power, IMU, storage, net, crypto, RTC) |
 | Supported boards | 10 |
-| Supported architectures | 6 (ESP32, S2, S3, C3, C6, H2) |
+| Supported architectures | 5 (ESP32, S2, S3, C3, C6) |
 | License | BSD 3-Clause |
 | Dependencies | All BSD/MIT/Apache-2.0 (no GPL) |
 
@@ -424,7 +424,7 @@ See [CLAUDE.md](CLAUDE.md) for architecture details and coding conventions.
 - [x] 100% Rust kernel (57 modules, 51,000+ LOC, 1231 tests)
 - [x] 15 Rust hardware drivers
 - [x] Multi-board support (10 boards)
-- [x] Multi-arch builds (ESP32, S2, S3, C3, C6, H2)
+- [x] Multi-arch builds (ESP32, S2, S3, C3, C6)
 - [x] Unified manifest system for apps, drivers, firmware
 - [x] Boot-from-JSON (board.json driven hardware init)
 - [x] Display server with swappable window managers

--- a/components/kernel_rs/Cargo.toml
+++ b/components/kernel_rs/Cargo.toml
@@ -29,7 +29,6 @@ esp32s2 = []
 esp32s3 = []
 esp32c3 = []
 esp32c6 = []
-esp32h2 = []
 
 [build-dependencies]
 embuild = "0.33"

--- a/components/kernel_rs/INTERFACES.md
+++ b/components/kernel_rs/INTERFACES.md
@@ -924,7 +924,7 @@ cargo test --target aarch64-apple-darwin -- --test-threads=1
 # Multi-arch ESP32 targets:
 cargo +esp build --release --target xtensa-esp32s3-espidf
 cargo +esp build --release --target xtensa-esp32-espidf
-cargo +esp build --release --target riscv32imc-esp-espidf   # C3, C6, H2
+cargo +esp build --release --target riscv32imc-esp-espidf   # C3/C6 family
 
 # CMakeLists.txt links the resulting libthistle_kernel.a:
 # target_link_libraries(${COMPONENT_LIB} INTERFACE kernel_rs)

--- a/components/kernel_rs/src/manifest.rs
+++ b/components/kernel_rs/src/manifest.rs
@@ -32,8 +32,6 @@ pub fn current_arch() -> &'static str {
     {
         #[cfg(feature = "esp32c6")]
         return "esp32c6";
-        #[cfg(feature = "esp32h2")]
-        return "esp32h2";
         // Default for riscv32 builds.
         "esp32c3"
     }

--- a/docs/devices.html
+++ b/docs/devices.html
@@ -167,14 +167,14 @@
 
     <div class="callout info">
       <div class="callout-title">One binary per architecture</div>
-      The kernel is compiled separately for each architecture family: one binary for Xtensa (ESP32, S2, S3) and one for RISC-V (C3, C6, H2). Apps and drivers are also architecture-specific. The catalog <code>arch</code> field filters entries to the correct binary for each device.
+      The kernel is compiled separately for each architecture family: one binary for Xtensa (ESP32, S2, S3) and one for RISC-V (C3, C6). Apps and drivers are also architecture-specific. The catalog <code>arch</code> field filters entries to the correct binary for each device.
     </div>
 
     <h2>How hardware detection works</h2>
     <p>When Recovery OS boots on a new or blank device, it auto-provisions hardware with no user configuration needed:</p>
 
     <ol class="steps">
-      <li><strong>Chip detection</strong> &mdash; Recovery reads the chip model register at boot. It knows whether it is running on ESP32, S2, S3, C3, C6, or H2, and selects the correct firmware architecture from the catalog.</li>
+      <li><strong>Chip detection</strong> &mdash; Recovery reads the chip model register at boot. It supports ESP32, S2, S3, C3, and C6, and selects the correct firmware architecture from the catalog.</li>
       <li><strong>Power rail enable</strong> &mdash; Before scanning, Recovery enables peripheral power rails (where applicable) to ensure devices are powered.</li>
       <li><strong>I2C bus scan</strong> &mdash; Probes addresses 0x08 through 0x77 on each I2C bus. Each responding address is looked up in the detection table.</li>
       <li><strong>SPI device probing</strong> &mdash; GPIO-level CS pin checks determine whether SPI devices (e-paper, LoRa SX1262, SD card) are present.</li>

--- a/docs/diagrams/build-pipeline.svg
+++ b/docs/diagrams/build-pipeline.svg
@@ -34,7 +34,7 @@
   <rect x="70" y="315" width="180" height="28" rx="6" fill="#ef4444" opacity="0.15"/>
   <text x="160" y="334" font-size="12" fill="#991b1b" text-anchor="middle" font-weight="700">thistle_os.bin</text>
 
-  <text x="160" y="362" font-size="9" fill="#991b1b" text-anchor="middle">ESP32 / S2 / S3 / C3 / C6 / H2</text>
+  <text x="160" y="362" font-size="9" fill="#991b1b" text-anchor="middle">ESP32 / S2 / S3 / C3 / C6</text>
 
   <!-- SDL2 Simulator (Blue) - center -->
   <rect x="310" y="155" width="180" height="220" rx="12" fill="#a5d8ff" stroke="#4a9eed" stroke-width="1.5" filter="url(#sf)"/>

--- a/docs/diagrams/hal-vtable.svg
+++ b/docs/diagrams/hal-vtable.svg
@@ -99,5 +99,5 @@
 
   <!-- Hardware (Red) -->
   <rect x="30" y="480" width="740" height="50" rx="12" fill="#ffc9c9" stroke="#ef4444" stroke-width="1.5" filter="url(#shd)"/>
-  <text x="400" y="510" font-size="13" fill="#991b1b" text-anchor="middle" font-weight="700">Physical Hardware (ESP32 / S2 / S3 / C3 / C6 / H2)</text>
+  <text x="400" y="510" font-size="13" fill="#991b1b" text-anchor="middle" font-weight="700">Physical Hardware (ESP32 / S2 / S3 / C3 / C6)</text>
 </svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -65,7 +65,7 @@
   <main class="main-content">
     <div class="page-header">
       <h1>ThistleOS</h1>
-      <p class="lead">An open-source operating system for the ESP32 chip family. Dynamic app loading, 15 Rust hardware drivers, swappable window managers, and LoRa mesh networking — all on a microcontroller. Supports ESP32, S2, S3 (Xtensa) and C3, C6, H2 (RISC-V).</p>
+      <p class="lead">An open-source operating system for the ESP32 chip family. Dynamic app loading, 15 Rust hardware drivers, swappable window managers, and LoRa mesh networking — all on a microcontroller. Supports ESP32, S2, S3 (Xtensa) and C3, C6 (RISC-V).</p>
       <a href="https://github.com/wan0net/thistle-os" class="edit-link">
         &#9998; Edit on GitHub
       </a>
@@ -90,7 +90,7 @@
       <li><strong>Apps are ELF files on an SD card.</strong> The kernel's ELF loader resolves symbols against a syscall table at runtime. No recompilation of the OS needed to install an app.</li>
       <li><strong>BSD 3-Clause throughout.</strong> No GPL components in the ThistleOS core; swap to any commercial use case without license headaches.</li>
       <li><strong>Recovery OS provisions from board catalogs.</strong> A separate, minimal Rust firmware in <code>ota_0</code> starts a WiFi captive portal, downloads the selected board profile, verifies catalog hashes, and installs matching drivers and firmware.</li>
-      <li><strong>Multi-arch.</strong> One kernel codebase targets Xtensa (ESP32, S2, S3) and RISC-V (C3, C6, H2). Board configs in JSON — no recompilation for new boards.</li>
+      <li><strong>Multi-arch.</strong> One kernel codebase targets Xtensa (ESP32, S2, S3) and RISC-V (C3, C6). Board configs in JSON — no recompilation for new boards.</li>
     </ul>
 
     <h2>Quick Start</h2>

--- a/docs/recovery.html
+++ b/docs/recovery.html
@@ -92,7 +92,7 @@
   &#x2514;&#x2500; NO &#x2500;&#x25BA; Boot Recovery OS (ota_0)
                      &#x2502;
                      &#x25BC;
-          [Step 0] Detect chip type (ESP32/S3/C3/S2/C6/H2)
+          [Step 0] Detect supported chip type (ESP32/S3/C3/S2/C6)
                      &#x2502;
                      &#x25BC;
           [Step 1] Check ota_1 partition state
@@ -160,7 +160,7 @@
     <h2>Building from source</h2>
     <p>The Recovery OS is a standard <code>esp-idf-svc</code> Rust project. You need:</p>
     <ul>
-      <li>Rust toolchain with the <code>xtensa-esp32s3-espidf</code> target (and/or RISC-V target for C3/C6/H2)</li>
+      <li>Rust toolchain with the <code>xtensa-esp32s3-espidf</code> target (and/or RISC-V target for C3/C6)</li>
       <li><code>espup</code> (Espressif's Rust toolchain installer)</li>
     </ul>
 

--- a/docs/security/artifact-manifests.md
+++ b/docs/security/artifact-manifests.md
@@ -31,6 +31,21 @@ board profile also retains manifest evidence beside `config/board.json`.
 Firmware evidence is retained as `config/firmware.manifest` and
 `config/firmware.manifest.sig` for boot-health and anti-rollback processing.
 
+Recovery stores the last activated firmware `security_version` in the default
+NVS partition under the `thistle_sec` namespace. A firmware bundle must carry a
+strictly greater signed value; equal values are treated as replays. Recovery
+commits and reads back the new value before selecting `ota_1` for boot. Storage
+read, commit, and readback failures stop activation. The counter is deliberately
+not erased when NVS is full or has an unsupported format.
+
+Offline SD updates use the same policy. Place these three release assets at:
+
+- `/sdcard/update/thistle_os.bin`
+- `/sdcard/update/thistle_os.bin.manifest`
+- `/sdcard/update/thistle_os.bin.manifest.sig`
+
+The older raw `thistle_os.bin.sig` file is no longer an installation authority.
+
 ## Migration
 
 1. Publish the payload, canonical manifest, and manifest signature.
@@ -38,7 +53,12 @@ Firmware evidence is retained as `config/firmware.manifest` and
 3. Keep the legacy fields only for older clients during the transition.
 4. Confirm the signed ID, destination, chip, board list, version, and security
    version before publishing.
-5. Never decrease or reuse a firmware security version for different bytes.
+5. Increase the firmware security version for every releasable firmware image.
+   Never decrease or reuse it, including for rebuilt bytes under the same
+   human-readable version.
+6. Devices without a stored counter accept their first valid nonzero signed
+   firmware version and persist it at activation. A failed NVS read is not
+   treated as a fresh device.
 
 Unsigned board profiles and raw payload signatures are intentionally rejected
 by the new Recovery installer.

--- a/recovery/src/anti_rollback.rs
+++ b/recovery/src/anti_rollback.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Monotonic firmware security-version policy for Recovery activation.
+
+/// Return the last committed firmware security version. A missing value is a
+/// fresh-device state; a storage error is not equivalent to a missing value.
+pub fn current_version(
+    mut load: impl FnMut() -> Result<Option<u32>, String>,
+) -> Result<u32, String> {
+    load()
+        .map(|value| value.unwrap_or(0))
+        .map_err(|error| format!("anti-rollback state unavailable: {error}"))
+}
+
+/// Require a strictly newer signed firmware security version.
+pub fn require_newer(
+    candidate: u32,
+    load: impl FnMut() -> Result<Option<u32>, String>,
+) -> Result<u32, String> {
+    if candidate == 0 {
+        return Err("firmware security version must be greater than zero".to_string());
+    }
+    let current = current_version(load)?;
+    if candidate <= current {
+        return Err(format!(
+            "firmware security version {candidate} is not newer than device version {current}"
+        ));
+    }
+    Ok(current)
+}
+
+/// Persist and read back the new floor before selecting the firmware for boot.
+/// If activation fails or power is lost after the commit, the advanced floor is
+/// intentionally retained so the old signed image cannot become eligible again.
+pub fn advance_before_activation(
+    candidate: u32,
+    mut load: impl FnMut() -> Result<Option<u32>, String>,
+    mut store: impl FnMut(u32) -> Result<(), String>,
+    activate: impl FnOnce() -> Result<(), String>,
+) -> Result<(), String> {
+    require_newer(candidate, &mut load)?;
+    store(candidate).map_err(|error| format!("anti-rollback commit failed: {error}"))?;
+    let persisted = current_version(&mut load)?;
+    if persisted != candidate {
+        return Err(format!(
+            "anti-rollback readback mismatch: wrote {candidate}, read {persisted}"
+        ));
+    }
+    activate()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::{Cell, RefCell};
+    use std::rc::Rc;
+
+    #[test]
+    fn stale_and_replayed_versions_are_rejected_before_activation() {
+        for candidate in [499, 500] {
+            let activated = Cell::new(false);
+            let result = advance_before_activation(
+                candidate,
+                || Ok(Some(500)),
+                |_| panic!("stale version must not be stored"),
+                || {
+                    activated.set(true);
+                    Ok(())
+                },
+            );
+            assert!(result.is_err());
+            assert!(!activated.get());
+        }
+    }
+
+    #[test]
+    fn fresh_device_commits_and_reads_back_before_activation() {
+        let state = Rc::new(RefCell::new(None));
+        let events = Rc::new(RefCell::new(Vec::new()));
+        advance_before_activation(
+            500,
+            {
+                let state = state.clone();
+                let events = events.clone();
+                move || {
+                    events.borrow_mut().push("load");
+                    Ok(*state.borrow())
+                }
+            },
+            {
+                let state = state.clone();
+                let events = events.clone();
+                move |value| {
+                    events.borrow_mut().push("store");
+                    *state.borrow_mut() = Some(value);
+                    Ok(())
+                }
+            },
+            {
+                let events = events.clone();
+                move || {
+                    events.borrow_mut().push("activate");
+                    Ok(())
+                }
+            },
+        )
+        .unwrap();
+        assert_eq!(*state.borrow(), Some(500));
+        assert_eq!(&*events.borrow(), &["load", "store", "load", "activate"]);
+    }
+
+    #[test]
+    fn unavailable_or_uncommitted_state_fails_closed() {
+        let activated = Cell::new(false);
+        let read_error = advance_before_activation(
+            500,
+            || Err("NVS read failed".to_string()),
+            |_| Ok(()),
+            || {
+                activated.set(true);
+                Ok(())
+            },
+        );
+        assert!(read_error.is_err());
+
+        let write_error = advance_before_activation(
+            500,
+            || Ok(None),
+            |_| Err("NVS commit failed".to_string()),
+            || {
+                activated.set(true);
+                Ok(())
+            },
+        );
+        assert!(write_error.is_err());
+        assert!(!activated.get());
+    }
+
+    #[test]
+    fn failed_activation_retains_floor_and_blocks_replay() {
+        let state = Rc::new(RefCell::new(Some(499)));
+        let first = advance_before_activation(
+            500,
+            {
+                let state = state.clone();
+                move || Ok(*state.borrow())
+            },
+            {
+                let state = state.clone();
+                move |value| {
+                    *state.borrow_mut() = Some(value);
+                    Ok(())
+                }
+            },
+            || Err("boot selector failed".to_string()),
+        );
+        assert!(first.is_err());
+        assert_eq!(*state.borrow(), Some(500));
+        assert!(require_newer(500, || Ok(*state.borrow())).is_err());
+    }
+
+    #[test]
+    fn readback_mismatch_blocks_activation() {
+        let activated = Cell::new(false);
+        let result = advance_before_activation(
+            501,
+            || Ok(Some(500)),
+            |_| Ok(()),
+            || {
+                activated.set(true);
+                Ok(())
+            },
+        );
+        assert!(result.is_err());
+        assert!(!activated.get());
+    }
+}

--- a/recovery/src/artifact_manifest.rs
+++ b/recovery/src/artifact_manifest.rs
@@ -163,7 +163,7 @@ impl ArtifactManifest {
         }
         if !matches!(
             self.arch.as_str(),
-            "esp32" | "esp32s2" | "esp32s3" | "esp32c3" | "esp32c6" | "esp32h2"
+            "esp32" | "esp32s2" | "esp32s3" | "esp32c3" | "esp32c6"
         ) {
             return Err(format!("unsupported architecture '{}'", self.arch));
         }
@@ -368,6 +368,9 @@ mod tests {
         ))
         .is_err());
         assert!(ArtifactManifest::parse(&canonical.replace("sha256=", "sha256=AB")).is_err());
+        assert!(
+            ArtifactManifest::parse(&canonical.replace("arch=esp32s3", "arch=esp32h2")).is_err()
+        );
         assert!(ArtifactManifest::parse(canonical.trim_end()).is_err());
         assert!(ArtifactManifest::parse(&(canonical.clone() + "extra=x\n")).is_err());
     }

--- a/recovery/src/main.rs
+++ b/recovery/src/main.rs
@@ -22,6 +22,7 @@ use esp_idf_svc::wifi::{
 
 use log::*;
 
+mod anti_rollback;
 mod artifact_manifest;
 mod bounded_io;
 mod bundle_transaction;
@@ -89,6 +90,15 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
+    // Keep one default-NVS partition handle for both the monotonic firmware
+    // security counter and WiFi. Recovery must not install without this state.
+    // Do not use the convenience initializer that erases a full or newer NVS
+    // partition: losing the security counter would reopen old signed images.
+    // A previously confirmed ota_1 boots above without depending on Recovery's
+    // update state; only update/install mode requires this fail-closed gate.
+    let nvs = EspDefaultNvsPartition::take_with(false)?;
+    recovery_ota::init_anti_rollback(nvs.clone())?;
+
     // Step 2: Check SD card for firmware
     info!("Checking SD card for firmware...");
     println!("Checking SD card...");
@@ -122,7 +132,6 @@ fn main() -> anyhow::Result<()> {
     }
 
     let sysloop = EspSystemEventLoop::take()?;
-    let nvs = EspDefaultNvsPartition::take()?;
     let mut wifi = BlockingWifi::wrap(
         EspWifi::new(
             Peripherals::take()?.modem,

--- a/recovery/src/recovery_ota.rs
+++ b/recovery/src/recovery_ota.rs
@@ -3,13 +3,16 @@
 
 use ed25519_dalek::{Signature, VerifyingKey};
 use esp_idf_svc::http::client::{Configuration as HttpConfig, EspHttpConnection};
+use esp_idf_svc::nvs::{EspDefaultNvs, EspDefaultNvsPartition};
 use esp_idf_sys::*;
 use log::*;
 use sha2::{Digest, Sha256};
 use std::io::{self, Read, Seek, Write};
 use std::path::Path;
 use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Mutex;
 
+use crate::anti_rollback;
 use crate::artifact_manifest::{ArtifactManifest, ArtifactType};
 use crate::bounded_io;
 use crate::bundle_transaction::{self, Boundary, BundleFile, RecoveryAction};
@@ -92,6 +95,10 @@ const MAX_EXECUTABLE_SIZE: usize = 2 * 1024 * 1024;
 const MAX_SIGNATURE_SIZE: usize = 64;
 const MAX_ARTIFACT_MANIFEST_SIZE: usize = 4096;
 const REQUIRE_EXECUTABLE_SIGNATURES: bool = true;
+const SECURITY_NVS_NAMESPACE: &str = "thistle_sec";
+const SECURITY_VERSION_KEY: &str = "fw_sec_ver";
+
+static SECURITY_NVS: Mutex<Option<EspDefaultNvs>> = Mutex::new(None);
 
 #[cfg(not(debug_assertions))]
 const RECOVERY_SIGNING_KEY: [u8; 32] = [
@@ -108,6 +115,57 @@ const RECOVERY_SIGNING_KEY: [u8; 32] = [
 /// Global progress counter (0-100) for the active bundle download.
 /// Updated by `recovery_download_board_bundle_for`; read by the web handler.
 pub static BUNDLE_PROGRESS: AtomicU8 = AtomicU8::new(0);
+
+pub fn init_anti_rollback(partition: EspDefaultNvsPartition) -> anyhow::Result<()> {
+    let nvs = EspDefaultNvs::new(partition, SECURITY_NVS_NAMESPACE, true)
+        .map_err(|error| anyhow::anyhow!("Failed to open anti-rollback state: {error}"))?;
+    let mut slot = SECURITY_NVS
+        .lock()
+        .map_err(|_| anyhow::anyhow!("Anti-rollback state lock is poisoned"))?;
+    if slot.is_some() {
+        anyhow::bail!("Anti-rollback state is already initialized");
+    }
+    *slot = Some(nvs);
+    Ok(())
+}
+
+fn load_security_version() -> Result<Option<u32>, String> {
+    let slot = SECURITY_NVS
+        .lock()
+        .map_err(|_| "state lock is poisoned".to_string())?;
+    let nvs = slot
+        .as_ref()
+        .ok_or_else(|| "state is not initialized".to_string())?;
+    nvs.get_u32(SECURITY_VERSION_KEY)
+        .map_err(|error| error.to_string())
+}
+
+fn store_security_version(value: u32) -> Result<(), String> {
+    let slot = SECURITY_NVS
+        .lock()
+        .map_err(|_| "state lock is poisoned".to_string())?;
+    let nvs = slot
+        .as_ref()
+        .ok_or_else(|| "state is not initialized".to_string())?;
+    nvs.set_u32(SECURITY_VERSION_KEY, value)
+        .map_err(|error| error.to_string())
+}
+
+fn require_newer_firmware(candidate: u32) -> anyhow::Result<()> {
+    anti_rollback::require_newer(candidate, load_security_version)
+        .map(|_| ())
+        .map_err(anyhow::Error::msg)
+}
+
+fn advance_security_version_and_select(candidate: u32) -> anyhow::Result<()> {
+    anti_rollback::advance_before_activation(
+        candidate,
+        load_security_version,
+        store_security_version,
+        || select_ota1_for_boot().map_err(|error| error.to_string()),
+    )
+    .map_err(anyhow::Error::msg)
+}
 
 #[derive(Debug)]
 pub enum Ota1State {
@@ -164,72 +222,66 @@ pub fn check_sd_firmware() -> bool {
 pub fn apply_sd_firmware() -> anyhow::Result<()> {
     info!("Applying firmware from SD: {}", SD_FIRMWARE_PATH);
 
+    let manifest_path = format!("{}.manifest", SD_FIRMWARE_PATH);
+    let manifest_signature_path = format!("{}.manifest.sig", SD_FIRMWARE_PATH);
+    let canonical = read_bounded_file(Path::new(&manifest_path), MAX_ARTIFACT_MANIFEST_SIZE)?;
+    let signature = read_signature_file(Path::new(&manifest_signature_path))?;
+    verify_ed25519_reader(&mut std::io::Cursor::new(&canonical), &signature)?;
+    let manifest =
+        ArtifactManifest::parse(std::str::from_utf8(&canonical)?).map_err(anyhow::Error::msg)?;
+    if manifest.artifact_type != ArtifactType::Firmware {
+        anyhow::bail!("SD manifest is not a firmware manifest");
+    }
+    let board = read_board_name();
+    manifest
+        .validate_for_device(detect_chip(), &board, 1)
+        .map_err(anyhow::Error::msg)?;
+    require_newer_firmware(manifest.security_version)?;
+
     let mut firmware = std::fs::File::open(SD_FIRMWARE_PATH)?;
     let firmware_size = usize::try_from(firmware.metadata()?.len())
         .map_err(|_| anyhow::anyhow!("Firmware size cannot be represented"))?;
-    if firmware_size == 0 || firmware_size > MAX_FIRMWARE_SIZE {
-        anyhow::bail!("Invalid firmware size: {} bytes", firmware_size);
+    if firmware_size != manifest.size || firmware_size > MAX_FIRMWARE_SIZE {
+        anyhow::bail!(
+            "SD firmware size does not match signed manifest: expected {}, found {}",
+            manifest.size,
+            firmware_size
+        );
     }
-    let sig = read_signature_file(Path::new(&format!("{}.sig", SD_FIRMWARE_PATH)))
-        .map_err(|_| anyhow::anyhow!("Missing or invalid SD firmware signature"))?;
-    verify_ed25519_reader(&mut firmware, &sig)?;
+    verify_sha256_file(Path::new(SD_FIRMWARE_PATH), &manifest.sha256)?;
     firmware.rewind()?;
 
-    write_ota1_reader(&mut firmware, firmware_size)?;
-    select_ota1_for_boot()?;
+    write_ota1_reader(&mut firmware, firmware_size, &manifest.sha256)?;
+    advance_security_version_and_select(manifest.security_version)?;
     Ok(())
 }
 
 /// Download firmware from app store catalog and flash to ota_1
 pub fn download_and_flash(catalog_url: &str) -> anyhow::Result<()> {
-    info!("Fetching catalog: {}", catalog_url);
-
-    // Fetch catalog JSON
-    let catalog_json = http_get_string(catalog_url, MAX_CATALOG_SIZE)?;
-
-    // Find the firmware entry (type = "firmware")
-    let fw_entry = find_catalog_entry_by_type(&catalog_json, "firmware")
-        .ok_or_else(|| anyhow::anyhow!("No firmware entry in catalog"))?;
-    let fw_url = json_extract_string(fw_entry, "url")
-        .ok_or_else(|| anyhow::anyhow!("Firmware entry missing url"))?;
-    let expected_sha = json_extract_string(fw_entry, "sha256")
-        .ok_or_else(|| anyhow::anyhow!("Firmware entry missing sha256"))?;
-    let sig_url = json_extract_string(fw_entry, "sig_url");
-
-    info!("Downloading firmware: {}", fw_url);
-    println!("Downloading: {}", fw_url);
-
-    let download_stage = DownloadStage::new(Path::new(BUNDLE_DOWNLOAD_DIR))?;
-    let firmware_path = download_stage.path("firmware.bin")?;
-    download_catalog_entry_to_file(
-        &fw_url,
-        Some(&expected_sha),
-        sig_url.as_deref(),
-        REQUIRE_EXECUTABLE_SIGNATURES,
-        MAX_FIRMWARE_SIZE,
-        &firmware_path,
-    )?;
-    let firmware_size = usize::try_from(std::fs::metadata(&firmware_path)?.len())?;
-    info!("Downloaded {} bytes", firmware_size);
-    println!("Downloaded {} bytes. Flashing...", firmware_size);
-
-    write_ota1_file(&firmware_path)?;
-    select_ota1_for_boot()?;
-
-    info!("Firmware flashed successfully");
-    Ok(())
+    recovery_download_board_bundle_for(catalog_url, &read_board_name()).map(|_| ())
 }
 
-fn write_ota1_file(path: &Path) -> anyhow::Result<()> {
+fn write_ota1_file(path: &Path, expected_sha256: &str) -> anyhow::Result<()> {
     let mut file = std::fs::File::open(path)?;
     let size = usize::try_from(file.metadata()?.len())
         .map_err(|_| anyhow::anyhow!("Firmware size cannot be represented"))?;
-    write_ota1_reader(&mut file, size)
+    write_ota1_reader(&mut file, size, expected_sha256)
 }
 
-fn write_ota1_reader(reader: &mut impl Read, total: usize) -> anyhow::Result<()> {
+fn write_ota1_reader(
+    reader: &mut impl Read,
+    total: usize,
+    expected_sha256: &str,
+) -> anyhow::Result<()> {
     if total == 0 || total > MAX_FIRMWARE_SIZE {
         anyhow::bail!("Invalid firmware size: {} bytes", total);
+    }
+    if expected_sha256.len() != 64
+        || !expected_sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        anyhow::bail!("Invalid signed firmware SHA-256");
     }
     unsafe {
         let part = esp_ota_get_next_update_partition(std::ptr::null());
@@ -245,6 +297,7 @@ fn write_ota1_reader(reader: &mut impl Read, total: usize) -> anyhow::Result<()>
 
         let mut chunk = [0u8; 4096];
         let mut written = 0;
+        let mut hasher = Sha256::new();
         while written < total {
             let wanted = chunk.len().min(total - written);
             let count = match reader.read(&mut chunk[..wanted]) {
@@ -258,6 +311,10 @@ fn write_ota1_reader(reader: &mut impl Read, total: usize) -> anyhow::Result<()>
                 esp_ota_abort(handle);
                 anyhow::bail!("Firmware ended at {} of {} bytes", written, total);
             }
+            // Hash the exact bytes passed to esp_ota_write. A pathname swap or
+            // in-place SD mutation can only leave unselected bytes in ota_1;
+            // it cannot pass this digest gate and reach the boot selector.
+            hasher.update(&chunk[..count]);
             let ret = esp_ota_write(handle, chunk[..count].as_ptr() as *const _, count);
             if ret != ESP_OK as i32 {
                 esp_ota_abort(handle);
@@ -273,6 +330,16 @@ fn write_ota1_reader(reader: &mut impl Read, total: usize) -> anyhow::Result<()>
             }
         }
         println!("\r  Progress: 100%");
+
+        let actual_sha256 = hex_lower(&hasher.finalize());
+        if actual_sha256 != expected_sha256 {
+            esp_ota_abort(handle);
+            anyhow::bail!(
+                "Flashed firmware digest mismatch: expected {}, got {}",
+                expected_sha256,
+                actual_sha256
+            );
+        }
 
         let ret = esp_ota_end(handle);
         if ret != ESP_OK as i32 {
@@ -1166,6 +1233,19 @@ fn read_signature_file(path: &Path) -> anyhow::Result<Vec<u8>> {
     Ok(std::fs::read(path)?)
 }
 
+fn read_bounded_file(path: &Path, max_size: usize) -> anyhow::Result<Vec<u8>> {
+    let size = usize::try_from(std::fs::metadata(path)?.len())
+        .map_err(|_| anyhow::anyhow!("File size cannot be represented"))?;
+    if size == 0 || size > max_size {
+        anyhow::bail!(
+            "File size {} is outside the 1..={} byte limit",
+            size,
+            max_size
+        );
+    }
+    Ok(std::fs::read(path)?)
+}
+
 fn verify_ed25519_reader(reader: &mut impl Read, signature: &[u8]) -> anyhow::Result<()> {
     if signature.len() != 64 {
         anyhow::bail!("Invalid Ed25519 signature size: {} bytes", signature.len());
@@ -1359,11 +1439,20 @@ pub fn recovery_download_board_bundle_for(
     if firmware_count != 1 || board_count != 1 {
         anyhow::bail!("Signed bundle must contain exactly one firmware and one board profile");
     }
+    let firmware_security_version = selected
+        .iter()
+        .find(|artifact| artifact.manifest.artifact_type == ArtifactType::Firmware)
+        .map(|artifact| artifact.manifest.security_version)
+        .ok_or_else(|| anyhow::anyhow!("Signed bundle has no firmware security version"))?;
+
+    // Reject rollback and replay before downloading or writing any artifact.
+    require_newer_firmware(firmware_security_version)?;
 
     let mut downloaded = 0u32;
     let download_stage = DownloadStage::new(Path::new(BUNDLE_DOWNLOAD_DIR))?;
     let mut bundle_files = Vec::new();
     let mut firmware_path: Option<std::path::PathBuf> = None;
+    let mut firmware_sha256: Option<String> = None;
 
     let mut destinations = std::collections::BTreeSet::new();
     for artifact in selected {
@@ -1399,6 +1488,7 @@ pub fn recovery_download_board_bundle_for(
                 staged_signature,
             )?);
             firmware_path = Some(staged);
+            firmware_sha256 = Some(manifest.sha256.clone());
         } else {
             info!(
                 "Downloading signed {} -> {}",
@@ -1450,12 +1540,17 @@ pub fn recovery_download_board_bundle_for(
 
     let firmware_path =
         firmware_path.ok_or_else(|| anyhow::anyhow!("Catalog has no compatible firmware image"))?;
+    let firmware_sha256 =
+        firmware_sha256.ok_or_else(|| anyhow::anyhow!("Catalog firmware has no signed SHA-256"))?;
     let sdcard_root = Path::new("/sdcard");
     bundle_transaction::install(
         sdcard_root,
         &bundle_files,
-        || write_ota1_file(&firmware_path).map_err(transaction_io_error),
-        || select_ota1_for_boot().map_err(transaction_io_error),
+        || write_ota1_file(&firmware_path, &firmware_sha256).map_err(transaction_io_error),
+        || {
+            advance_security_version_and_select(firmware_security_version)
+                .map_err(transaction_io_error)
+        },
         |boundary| {
             log_transaction_boundary(boundary);
             Ok(())
@@ -1571,6 +1666,7 @@ pub fn recovery_bundle_plan_json(catalog_url: &str, board_name: &str) -> anyhow:
     let catalog_json = http_get_string(catalog_url, MAX_CATALOG_SIZE)?;
     let chip = detect_chip();
     let mut entries: Vec<String> = Vec::new();
+    let mut firmware_security_versions = Vec::new();
 
     for artifact in fetch_verified_manifests(&catalog_json)? {
         let manifest = artifact.manifest;
@@ -1586,6 +1682,9 @@ pub fn recovery_bundle_plan_json(catalog_url: &str, board_name: &str) -> anyhow:
         manifest
             .validate_for_device(chip, board_name, 1)
             .map_err(anyhow::Error::msg)?;
+        if manifest.artifact_type == ArtifactType::Firmware {
+            firmware_security_versions.push(manifest.security_version);
+        }
         entries.push(format!(
             r#"{{"id":"{}","type":"{}","version":"{}","destination":"{}"}}"#,
             manifest.id,
@@ -1594,6 +1693,11 @@ pub fn recovery_bundle_plan_json(catalog_url: &str, board_name: &str) -> anyhow:
             manifest.destination,
         ));
     }
+
+    if firmware_security_versions.len() != 1 {
+        anyhow::bail!("Signed bundle plan must contain exactly one firmware image");
+    }
+    require_newer_firmware(firmware_security_versions[0])?;
 
     Ok(format!(
         r#"{{"ok":true,"board":"{}","chip":"{}","catalog_source":"{}","count":{},"entries":[{}]}}"#,

--- a/recovery/src/recovery_ota.rs
+++ b/recovery/src/recovery_ota.rs
@@ -23,7 +23,7 @@ use crate::catalog_path::validate_catalog_id;
 // ---------------------------------------------------------------------------
 
 /// Detect the ESP32 chip variant from the ROM at runtime.
-/// Returns a slug like "esp32", "esp32s2", "esp32s3", "esp32c3", "esp32c6", "esp32h2".
+/// Returns a supported slug like "esp32", "esp32s2", "esp32s3", "esp32c3", or "esp32c6".
 ///
 /// Uses `esp_chip_info()` which is available on all ESP32 variants via ROM.
 /// The `model` field maps to the `esp_chip_model_t` enum in esp_system.h.
@@ -55,7 +55,6 @@ pub fn detect_chip() -> &'static str {
             9 => "esp32s3",  // CHIP_ESP32S3
             5 => "esp32c3",  // CHIP_ESP32C3
             13 => "esp32c6", // CHIP_ESP32C6
-            16 => "esp32h2", // CHIP_ESP32H2
             _ => "unknown",
         }
     }
@@ -63,11 +62,11 @@ pub fn detect_chip() -> &'static str {
 
 /// Returns a human-readable architecture family for display purposes.
 /// Xtensa cores: esp32, esp32s2, esp32s3.
-/// RISC-V cores: esp32c3, esp32c6, esp32h2.
+/// RISC-V cores: esp32c3, esp32c6.
 pub fn chip_arch_family(chip: &str) -> &'static str {
     match chip {
         "esp32" | "esp32s2" | "esp32s3" => "xtensa",
-        "esp32c3" | "esp32c6" | "esp32h2" => "riscv32",
+        "esp32c3" | "esp32c6" => "riscv32",
         _ => "unknown",
     }
 }

--- a/tools/sign.py
+++ b/tools/sign.py
@@ -191,7 +191,7 @@ def main():
     manifest_parser.add_argument("--security-version", required=True, type=int)
     manifest_parser.add_argument(
         "--arch", required=True,
-        choices=["esp32", "esp32s2", "esp32s3", "esp32c3", "esp32c6", "esp32h2"],
+        choices=["esp32", "esp32s2", "esp32s3", "esp32c3", "esp32c6"],
     )
     manifest_parser.add_argument(
         "--compatible-board", required=True, action="append",

--- a/tools/validate_board_catalog.py
+++ b/tools/validate_board_catalog.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 
 REQUIRED_BOARD_KEYS = {"name", "arch", "board_id", "version"}
-VALID_ARCHES = {"esp32", "esp32s2", "esp32s3", "esp32c3", "esp32c6", "esp32h2"}
+VALID_ARCHES = {"esp32", "esp32s2", "esp32s3", "esp32c3", "esp32c6"}
 DRIVER_ENTRY_ALIASES = {
     "lcd-st7789-i80.drv.elf": "lcd-st7789.drv.elf",
     "qmi8658.drv.elf": "accel-qmi8658.drv.elf",


### PR DESCRIPTION
## Summary
- persist the last activated signed firmware `security_version` in a dedicated NVS namespace
- reject equal-version replays and lower-version rollbacks before downloads or writes
- commit and read back the higher version before selecting `ota_1`, retaining the advanced floor if activation is interrupted
- require signed manifests for offline SD updates and hash the exact bytes written to the inactive OTA partition
- route the legacy catalog helper through the secured signed-bundle installer and document the migration
- descope ESP32-H2 because Recovery requires WiFi and H2 has no WiFi radio; remove it from signing, validation, feature, and supported-platform documentation

Closes #65

## Power-loss and failure behavior
Recovery never treats an NVS read error as fresh state and disables the library fallback that erases full or newer-format NVS. A fresh device may enroll its first valid nonzero signed version. Once a higher counter is committed, failed boot selection or power loss does not lower it.

## Validation
- anti-rollback regression tests: 5 passed
- signed-manifest regression tests: 4 passed, including ESP32-H2 rejection
- signing-tool tests: 8 passed
- board catalog: 13 profiles generated and validated against the five supported architectures
- kernel host suite: 1,318 passed
- Recovery ESP32-S3 check and optimized release build: passed (1.6 MB)
- Recovery checks: ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C6 passed
- Rust formatting, workflow YAML parse, and patch integrity: passed

## Scope note
This also closes the analogous Recovery-side path-swap window by hashing the exact bytes passed to `esp_ota_write`. Issue #75 remains open because its reported sink is the separate main-kernel SD OTA implementation.