### PR TITLE
Migrate password KDFs to versioned Argon2id envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ ThistleOS ships with 14 apps that demonstrate the platform. All are built-in but
 | **Flashlight** | Full-screen white + SOS Morse code pattern |
 | **Weather** | IMU sensor dashboard (barometer, temperature) |
 | **Terminal** | System console with built-in diagnostic commands |
-| **Vault** | AES-256 encrypted password manager (PBKDF2 key derivation) |
+| **Vault** | AES-256 encrypted password manager (versioned Argon2id key derivation) |
 
 ## Themes
 
@@ -319,7 +319,7 @@ Signing and verification at every level — from boot to apps:
 - The **developer** holds the Ed25519 private key (never on-device)
 - The **device** holds only the public key (embedded in Recovery firmware)
 - The device **cannot forge signatures** — it can only verify them
-- Cryptography uses **ed25519-dalek** (Rust) for signing and **mbedtls** (ESP-IDF) for TLS; symmetric crypto (AES-256, HMAC-SHA256, PBKDF2) goes through the kernel crypto module
+- Cryptography uses **ed25519-dalek** (Rust) for signing and **mbedtls** (ESP-IDF) for TLS; symmetric crypto and password derivation (AES-256, HMAC-SHA256, Argon2id, legacy-migration PBKDF2) go through the kernel crypto module
 
 **Kernel crypto module:**
 The kernel contains a platform-independent crypto layer (`components/kernel_rs/src/crypto.rs`). It dispatches through the `hal_crypto_driver_t` vtable first — on ESP32-S3 this can use the hardware AES and SHA accelerators. When no hardware crypto driver is registered (simulator, WASM, or boards without hardware crypto), it falls back to pure Rust software implementations transparently. The Vault app uses this kernel crypto on all platforms, including the SDL2 simulator and the planned WASM web simulator.
@@ -466,6 +466,7 @@ All dependencies are permissively licensed. See [THIRD_PARTY_LICENSES.md](THIRD_
 | mbedtls | Apache-2.0 | TLS, AES, hashing |
 | aes | MIT/Apache-2.0 | Rust software AES-256 |
 | hmac | MIT/Apache-2.0 | Rust software HMAC |
+| argon2 | MIT/Apache-2.0 | Memory-hard password key derivation |
 | pbkdf2 | MIT/Apache-2.0 | Rust software PBKDF2 |
 | getrandom | MIT/Apache-2.0 | Rust CSPRNG entropy |
 | embedded-graphics | MIT/Apache-2.0 | Rust 2D graphics primitives |

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -230,7 +230,7 @@ Full text: https://github.com/LoupVaillant/Monocypher/blob/master/LICENCE.md
 
 **License:** Apache License 2.0
 **Source:** https://github.com/Mbed-TLS/mbedtls
-**Used for:** TLS (HTTPS app store), AES-256-CBC + PBKDF2-SHA256 (Vault), SHA-256 OTA verification. Included via ESP-IDF.
+**Used for:** TLS (HTTPS app store), AES-256-CBC (Vault), SHA-256 OTA verification, and legacy PBKDF2 vault migration. Included via ESP-IDF.
 
 ```
 Copyright The Mbed TLS Contributors
@@ -346,6 +346,17 @@ and: https://github.com/esp-rs/esp-idf-hal/blob/master/LICENSE-APACHE
 
 ---
 
+## argon2 (RustCrypto)
+
+**License:** MIT OR Apache-2.0
+**Source:** https://github.com/RustCrypto/password-hashes/tree/master/argon2
+**Used for:** Argon2id password key derivation for vault and messaging envelopes.
+
+Full text: https://github.com/RustCrypto/password-hashes/blob/master/LICENSE-MIT
+and: https://github.com/RustCrypto/password-hashes/blob/master/LICENSE-APACHE
+
+---
+
 ## esp-idf-svc (Rust)
 
 **License:** MIT OR Apache-2.0
@@ -377,6 +388,6 @@ All dependencies are compatible with the ThistleOS BSD 3-Clause license:
 | MIT | Yes | LVGL, FreeRTOS, RadioLib, libcurl, Unity, esp-rs crates |
 | BSD-2-Clause | Yes | Monocypher |
 | zlib | Yes | SDL2 |
-| MIT OR Apache-2.0 | Yes | esp-idf-hal, esp-idf-svc, esp-idf-sys |
+| MIT OR Apache-2.0 | Yes | argon2, esp-idf-hal, esp-idf-svc, esp-idf-sys |
 
 No GPL, LGPL, AGPL, or other copyleft licenses are present in this project.

--- a/app_sdk/include/thistle_app.h
+++ b/app_sdk/include/thistle_app.h
@@ -79,6 +79,7 @@ extern int thistle_crypto_aes256_cbc_encrypt(const uint8_t *key, const uint8_t *
 extern int thistle_crypto_aes256_cbc_decrypt(const uint8_t *key, const uint8_t *iv, const uint8_t *ciphertext, size_t len, uint8_t *plaintext_out);
 extern int thistle_crypto_aes128_ecb_encrypt(const uint8_t *key, const uint8_t *plaintext, size_t len, uint8_t *ciphertext_out);
 extern int thistle_crypto_aes128_ecb_decrypt(const uint8_t *key, const uint8_t *ciphertext, size_t len, uint8_t *plaintext_out);
+extern int thistle_crypto_argon2id(const uint8_t *password, size_t password_len, const uint8_t *salt, size_t salt_len, uint8_t *key_out, size_t key_len);
 extern int thistle_crypto_pbkdf2_sha256(const char *password, const uint8_t *salt, size_t salt_len, uint32_t iterations, uint8_t *key_out, size_t key_len);
 extern int thistle_crypto_random(uint8_t *buf, size_t len);
 extern int thistle_crypto_ed25519_keygen(uint8_t *private_key_out, uint8_t *public_key_out);

--- a/apps/vault/vault/vault_app.h
+++ b/apps/vault/vault/vault_app.h
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * ThistleOS — Vault app public interface
  *
- * AES-256-CBC encrypted password vault, protected by a PBKDF2-derived key.
+ * AES-256-CBC encrypted password vault, protected by an Argon2id-derived key.
  * Hardware AES acceleration used on ESP32-S3 via mbedtls.
  */
 #pragma once

--- a/apps/vault/vault/vault_ui.c
+++ b/apps/vault/vault/vault_ui.c
@@ -3,12 +3,12 @@
  * ThistleOS — Vault app UI
  *
  * Three-screen password vault:
- *   Lock screen  — master-password entry, PBKDF2 key derivation
+ *   Lock screen  — master-password entry, Argon2id key derivation
  *   Entry list   — scrollable list of stored credentials
  *   Entry detail — name / username / password / notes editor
  *
- * Encryption: AES-256-CBC + PBKDF2-HMAC-SHA256 + HMAC-SHA256 integrity.
- * File layout: [16-byte salt][16-byte IV][encrypted JSON][32-byte HMAC]
+ * Encryption: AES-256-CBC + Argon2id + HMAC-SHA256 integrity.
+ * V2 layout: [versioned KDF header][encrypted JSON][32-byte HMAC]
  *
  * Works on all platforms (ESP32, simulator, WASM) via the kernel crypto module.
  */
@@ -34,6 +34,7 @@ extern int thistle_crypto_hmac_verify(const unsigned char *key, unsigned int key
 extern int thistle_crypto_aes256_cbc_encrypt(const unsigned char *key, const unsigned char *iv, const unsigned char *plaintext, unsigned int len, unsigned char *ciphertext_out);
 extern int thistle_crypto_aes256_cbc_decrypt(const unsigned char *key, const unsigned char *iv, const unsigned char *ciphertext, unsigned int len, unsigned char *plaintext_out);
 extern int thistle_crypto_pbkdf2_sha256(const char *password, const unsigned char *salt, unsigned int salt_len, unsigned int iterations, unsigned char *key_out, unsigned int key_len);
+extern int thistle_crypto_argon2id(const unsigned char *password, size_t password_len, const unsigned char *salt, size_t salt_len, unsigned char *key_out, size_t key_len);
 extern int thistle_crypto_random(unsigned char *buf, unsigned int len);
 
 static const char *TAG = "vault_ui";
@@ -50,16 +51,29 @@ static int s_app_h = 296;
 #define MAX_ENTRIES   32
 
 #define VAULT_PATH   THISTLE_SDCARD "/config/vault.enc"
+#define VAULT_TEMP_PATH THISTLE_SDCARD "/config/vault.enc.tmp"
+#define VAULT_BACKUP_PATH THISTLE_SDCARD "/config/vault.enc.bak"
 #define VAULT_CONFIG_DIR  THISTLE_SDCARD "/config"
 
-/* File format offsets */
+/* Legacy v1 file format offsets */
 #define SALT_LEN     16
 #define IV_LEN       16
 #define HMAC_LEN     32
-#define HEADER_LEN   (SALT_LEN + IV_LEN)   /* 32 bytes before ciphertext */
+#define LEGACY_HEADER_LEN (SALT_LEN + IV_LEN)
 
-/* PBKDF2 iterations — deliberately slow */
-#define PBKDF2_ITER  10000
+/* Versioned v2 KDF envelope. Numeric values are little-endian. */
+#define VAULT_MAGIC_LEN       4
+#define VAULT_VERSION         2
+#define VAULT_KDF_ARGON2ID    1
+#define ARGON2_MEMORY_KIB     64
+#define ARGON2_TIME_COST      6
+#define ARGON2_LANES          1
+#define V2_HEADER_LEN         52
+#define V2_SALT_OFFSET        20
+#define V2_IV_OFFSET          (V2_SALT_OFFSET + SALT_LEN)
+#define LEGACY_PBKDF2_ITER    10000
+
+static const uint8_t VAULT_MAGIC[VAULT_MAGIC_LEN] = {'T', 'H', 'V', '2'};
 
 /* ------------------------------------------------------------------ */
 /* Data types                                                           */
@@ -127,11 +141,21 @@ static esp_err_t vault_save(void);
 /* Crypto helpers — unified, backed by the kernel crypto module        */
 /* ------------------------------------------------------------------ */
 
-static esp_err_t derive_key(const char *password,
-                             const uint8_t salt[SALT_LEN],
-                             uint8_t key[32])
+static esp_err_t derive_key_v2(const char *password,
+                                const uint8_t salt[SALT_LEN],
+                                uint8_t key[32])
 {
-    return (thistle_crypto_pbkdf2_sha256(password, salt, SALT_LEN, PBKDF2_ITER, key, 32) == 0)
+    return (thistle_crypto_argon2id((const unsigned char *)password, strlen(password),
+                                    salt, SALT_LEN, key, 32) == 0)
+           ? ESP_OK : ESP_FAIL;
+}
+
+static esp_err_t derive_key_legacy(const char *password,
+                                    const uint8_t salt[SALT_LEN],
+                                    uint8_t key[32])
+{
+    return (thistle_crypto_pbkdf2_sha256(password, salt, SALT_LEN,
+                                         LEGACY_PBKDF2_ITER, key, 32) == 0)
            ? ESP_OK : ESP_FAIL;
 }
 
@@ -153,16 +177,47 @@ static esp_err_t vault_decrypt(const uint8_t *ciphertext, size_t len,
            ? ESP_OK : ESP_FAIL;
 }
 
-static void compute_hmac(const uint8_t *data, size_t data_len,
-                          const uint8_t key[32],
-                          uint8_t hmac_out[HMAC_LEN])
+static esp_err_t compute_hmac(const uint8_t *data, size_t data_len,
+                              const uint8_t key[32],
+                              uint8_t hmac_out[HMAC_LEN])
 {
-    thistle_crypto_hmac_sha256(key, 32, data, data_len, hmac_out);
+    return (thistle_crypto_hmac_sha256(key, 32, data, data_len, hmac_out) == 0)
+           ? ESP_OK : ESP_FAIL;
 }
 
-static void fill_random(uint8_t *buf, size_t len)
+static esp_err_t fill_random(uint8_t *buf, size_t len)
 {
-    thistle_crypto_random(buf, len);
+    if (thistle_crypto_random(buf, len) != 0) {
+        memset(buf, 0, len);
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+static uint32_t read_u32_le(const uint8_t *p)
+{
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) |
+           ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static void write_u32_le(uint8_t *p, uint32_t value)
+{
+    p[0] = (uint8_t)value;
+    p[1] = (uint8_t)(value >> 8);
+    p[2] = (uint8_t)(value >> 16);
+    p[3] = (uint8_t)(value >> 24);
+}
+
+static bool valid_v2_header(const uint8_t *header, size_t len)
+{
+    return len >= V2_HEADER_LEN &&
+           memcmp(header, VAULT_MAGIC, VAULT_MAGIC_LEN) == 0 &&
+           header[4] == VAULT_VERSION &&
+           header[5] == VAULT_KDF_ARGON2ID &&
+           header[6] == 0 && header[7] == 0 &&
+           read_u32_le(header + 8) == ARGON2_MEMORY_KIB &&
+           read_u32_le(header + 12) == ARGON2_TIME_COST &&
+           read_u32_le(header + 16) == ARGON2_LANES;
 }
 
 /* ------------------------------------------------------------------ */
@@ -360,6 +415,41 @@ static bool vault_file_exists(void)
     return (stat(VAULT_PATH, &st) == 0);
 }
 
+static esp_err_t recover_interrupted_vault_write(void)
+{
+    struct stat st;
+    if (stat(VAULT_PATH, &st) == 0) {
+        return ESP_OK;
+    }
+    if (stat(VAULT_BACKUP_PATH, &st) == 0 &&
+        rename(VAULT_BACKUP_PATH, VAULT_PATH) == 0) {
+        ESP_LOGW(TAG, "Recovered vault backup after interrupted write");
+        return ESP_OK;
+    }
+    return ESP_ERR_NOT_FOUND;
+}
+
+static esp_err_t replace_vault_file(void)
+{
+    bool had_original = vault_file_exists();
+    remove(VAULT_BACKUP_PATH);
+    if (had_original && rename(VAULT_PATH, VAULT_BACKUP_PATH) != 0) {
+        remove(VAULT_TEMP_PATH);
+        return ESP_FAIL;
+    }
+    if (rename(VAULT_TEMP_PATH, VAULT_PATH) != 0) {
+        if (had_original) {
+            rename(VAULT_BACKUP_PATH, VAULT_PATH);
+        }
+        remove(VAULT_TEMP_PATH);
+        return ESP_FAIL;
+    }
+    if (had_original) {
+        remove(VAULT_BACKUP_PATH);
+    }
+    return ESP_OK;
+}
+
 /*
  * vault_load — open vault file, verify HMAC, decrypt, parse JSON.
  *
@@ -373,14 +463,18 @@ static bool vault_file_exists(void)
 static esp_err_t vault_load(const char *master_pw)
 {
     ensure_config_dir();
+    recover_interrupted_vault_write();
 
     if (!vault_file_exists()) {
         /* First use: create empty vault */
         ESP_LOGI(TAG, "First use — creating new vault");
-        fill_random(s_vault.salt, SALT_LEN);
+        if (fill_random(s_vault.salt, SALT_LEN) != ESP_OK) {
+            ESP_LOGE(TAG, "Salt generation failed on first use");
+            return ESP_FAIL;
+        }
         s_vault.entry_count = 0;
 
-        esp_err_t rc = derive_key(master_pw, s_vault.salt, s_vault.derived_key);
+        esp_err_t rc = derive_key_v2(master_pw, s_vault.salt, s_vault.derived_key);
         if (rc != ESP_OK) {
             ESP_LOGE(TAG, "Key derivation failed on first use");
             return rc;
@@ -389,8 +483,9 @@ static esp_err_t vault_load(const char *master_pw)
         /* Save the (empty) vault immediately */
         esp_err_t save_rc = vault_save();
         if (save_rc != ESP_OK) {
-            ESP_LOGW(TAG, "Could not write initial vault file: %d", save_rc);
-            /* Not fatal — carry on with in-memory empty vault */
+            memset(s_vault.derived_key, 0, sizeof(s_vault.derived_key));
+            ESP_LOGE(TAG, "Could not write initial vault file: %d", save_rc);
+            return save_rc;
         }
         return ESP_OK;
     }
@@ -402,8 +497,8 @@ static esp_err_t vault_load(const char *master_pw)
     long fsz = ftell(f);
     fseek(f, 0, SEEK_SET);
 
-    /* Minimum: salt + IV + 16 bytes ciphertext + HMAC */
-    if (fsz < (long)(HEADER_LEN + 16 + HMAC_LEN)) {
+    /* Minimum legacy envelope: salt + IV + one AES block + HMAC. */
+    if (fsz < (long)(LEGACY_HEADER_LEN + 16 + HMAC_LEN)) {
         fclose(f);
         ESP_LOGE(TAG, "Vault file too small (%ld bytes)", fsz);
         return ESP_ERR_INVALID_SIZE;
@@ -415,16 +510,34 @@ static esp_err_t vault_load(const char *master_pw)
     fclose(f);
     if (nread_vault != (size_t)fsz) { free(filebuf); return ESP_ERR_INVALID_SIZE; }
 
-    /* Split file */
-    uint8_t *file_salt = filebuf;                            /* [0..15]  */
-    uint8_t *file_iv   = filebuf + SALT_LEN;                /* [16..31] */
-    uint8_t *ciphertext = filebuf + HEADER_LEN;             /* [32..fsz-HMAC_LEN-1] */
-    size_t   cipher_len = (size_t)fsz - HEADER_LEN - HMAC_LEN;
+    bool is_v2 = memcmp(filebuf, VAULT_MAGIC, VAULT_MAGIC_LEN) == 0;
+    size_t header_len = is_v2 ? V2_HEADER_LEN : LEGACY_HEADER_LEN;
+    if (is_v2 && !valid_v2_header(filebuf, (size_t)fsz)) {
+        free(filebuf);
+        ESP_LOGE(TAG, "Unsupported or malformed vault KDF header");
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+    if ((size_t)fsz < header_len + 16 + HMAC_LEN) {
+        free(filebuf);
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    uint8_t *file_salt = is_v2 ? filebuf + V2_SALT_OFFSET : filebuf;
+    uint8_t *file_iv = is_v2 ? filebuf + V2_IV_OFFSET : filebuf + SALT_LEN;
+    uint8_t *ciphertext = filebuf + header_len;
+    size_t cipher_len = (size_t)fsz - header_len - HMAC_LEN;
     uint8_t *file_hmac  = filebuf + fsz - HMAC_LEN;
+
+    if (cipher_len == 0 || cipher_len % 16 != 0) {
+        free(filebuf);
+        return ESP_ERR_INVALID_SIZE;
+    }
 
     /* Derive key from candidate password */
     uint8_t candidate_key[32];
-    esp_err_t rc = derive_key(master_pw, file_salt, candidate_key);
+    esp_err_t rc = is_v2
+        ? derive_key_v2(master_pw, file_salt, candidate_key)
+        : derive_key_legacy(master_pw, file_salt, candidate_key);
     if (rc != ESP_OK) {
         free(filebuf);
         return rc;
@@ -467,13 +580,42 @@ static esp_err_t vault_load(const char *master_pw)
     int cnt = json_to_entries((char *)plaintext);
     free(plaintext);
 
-    /* Accept key and salt only after successful authentication */
-    memcpy(s_vault.salt, file_salt, SALT_LEN);
-    memcpy(s_vault.derived_key, candidate_key, 32);
+    if (cnt < 0) {
+        free(filebuf);
+        memset(candidate_key, 0, sizeof(candidate_key));
+        ESP_LOGE(TAG, "Authenticated vault payload is malformed");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    s_vault.entry_count = cnt;
+
+    /* Legacy files are authenticated first, then atomically re-keyed to v2. */
+    if (!is_v2) {
+        uint8_t migrated_salt[SALT_LEN];
+        uint8_t migrated_key[32];
+        if (fill_random(migrated_salt, SALT_LEN) != ESP_OK ||
+            derive_key_v2(master_pw, migrated_salt, migrated_key) != ESP_OK) {
+            memset(candidate_key, 0, sizeof(candidate_key));
+            free(filebuf);
+            return ESP_FAIL;
+        }
+        memcpy(s_vault.salt, migrated_salt, SALT_LEN);
+        memcpy(s_vault.derived_key, migrated_key, sizeof(migrated_key));
+        memset(migrated_key, 0, sizeof(migrated_key));
+        if (vault_save() != ESP_OK) {
+            memset(s_vault.derived_key, 0, sizeof(s_vault.derived_key));
+            memset(candidate_key, 0, sizeof(candidate_key));
+            free(filebuf);
+            ESP_LOGE(TAG, "Legacy vault migration failed; original retained");
+            return ESP_FAIL;
+        }
+        ESP_LOGI(TAG, "Migrated legacy vault to Argon2id v2");
+    } else {
+        memcpy(s_vault.salt, file_salt, SALT_LEN);
+        memcpy(s_vault.derived_key, candidate_key, 32);
+    }
     memset(candidate_key, 0, 32);
     free(filebuf);
-
-    s_vault.entry_count = (cnt >= 0) ? cnt : 0;
     return ESP_OK;
 }
 
@@ -497,7 +639,10 @@ static esp_err_t vault_save(void)
 
     /* Generate fresh IV for this save */
     uint8_t iv[IV_LEN];
-    fill_random(iv, IV_LEN);
+    if (fill_random(iv, IV_LEN) != ESP_OK) {
+        free(padded);
+        return ESP_FAIL;
+    }
 
     /* Encrypt */
     uint8_t *ciphertext = (uint8_t *)malloc(padded_len);
@@ -509,25 +654,42 @@ static esp_err_t vault_save(void)
     free(padded);
     if (rc != ESP_OK) { free(ciphertext); return rc; }
 
-    /* Build file: salt || IV || ciphertext */
-    size_t body_len = SALT_LEN + IV_LEN + padded_len;
+    /* Build the authenticated, versioned v2 envelope. */
+    size_t body_len = V2_HEADER_LEN + padded_len;
     uint8_t *filebuf = (uint8_t *)malloc(body_len + HMAC_LEN);
     if (!filebuf) { free(ciphertext); return ESP_ERR_NO_MEM; }
 
-    memcpy(filebuf,                  s_vault.salt, SALT_LEN);
-    memcpy(filebuf + SALT_LEN,       iv,           IV_LEN);
-    memcpy(filebuf + SALT_LEN + IV_LEN, ciphertext, padded_len);
+    memcpy(filebuf, VAULT_MAGIC, VAULT_MAGIC_LEN);
+    filebuf[4] = VAULT_VERSION;
+    filebuf[5] = VAULT_KDF_ARGON2ID;
+    filebuf[6] = 0;
+    filebuf[7] = 0;
+    write_u32_le(filebuf + 8, ARGON2_MEMORY_KIB);
+    write_u32_le(filebuf + 12, ARGON2_TIME_COST);
+    write_u32_le(filebuf + 16, ARGON2_LANES);
+    memcpy(filebuf + V2_SALT_OFFSET, s_vault.salt, SALT_LEN);
+    memcpy(filebuf + V2_IV_OFFSET, iv, IV_LEN);
+    memcpy(filebuf + V2_HEADER_LEN, ciphertext, padded_len);
     free(ciphertext);
 
     /* Compute HMAC over (salt || IV || ciphertext) */
-    compute_hmac(filebuf, body_len, s_vault.derived_key,
-                 filebuf + body_len);
+    if (compute_hmac(filebuf, body_len, s_vault.derived_key,
+                     filebuf + body_len) != ESP_OK) {
+        free(filebuf);
+        return ESP_FAIL;
+    }
 
-    FILE *f = fopen(VAULT_PATH, "wb");
+    FILE *f = fopen(VAULT_TEMP_PATH, "wb");
     if (!f) { free(filebuf); return ESP_ERR_NOT_FOUND; }
-    fwrite(filebuf, 1, body_len + HMAC_LEN, f);
-    fclose(f);
+    size_t total_len = body_len + HMAC_LEN;
+    bool write_ok = fwrite(filebuf, 1, total_len, f) == total_len;
+    bool close_ok = fclose(f) == 0;
     free(filebuf);
+
+    if (!write_ok || !close_ok || replace_vault_file() != ESP_OK) {
+        remove(VAULT_TEMP_PATH);
+        return ESP_FAIL;
+    }
 
     ESP_LOGI(TAG, "Vault saved (%d entries)", s_vault.entry_count);
     return ESP_OK;
@@ -1002,6 +1164,7 @@ esp_err_t vault_ui_create(lv_obj_t *parent)
     lv_obj_set_size(s_vault.master_pw_ta, 220, 28);
     lv_obj_align(s_vault.master_pw_ta, LV_ALIGN_CENTER, 0, -20);
     lv_textarea_set_one_line(s_vault.master_pw_ta, true);
+    lv_textarea_set_max_length(s_vault.master_pw_ta, 128);
     lv_textarea_set_password_mode(s_vault.master_pw_ta, true);
     lv_textarea_set_placeholder_text(s_vault.master_pw_ta, "Master password");
     lv_obj_set_style_text_font(s_vault.master_pw_ta, &lv_font_montserrat_14, LV_PART_MAIN);

--- a/components/kernel_rs/Cargo.lock
+++ b/components/kernel_rs/Cargo.lock
@@ -20,6 +20,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+ "zeroize",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +61,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "block-buffer"
@@ -212,6 +234,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -524,6 +547,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41af26158b0f5530f7b79955006c2727cd23d0d8e7c3109dc316db0a919784dd"
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +793,7 @@ name = "thistle-kernel"
 version = "0.1.0"
 dependencies = [
  "aes",
+ "argon2",
  "curve25519-dalek 5.0.0",
  "ed25519-dalek",
  "embedded-graphics",

--- a/components/kernel_rs/Cargo.toml
+++ b/components/kernel_rs/Cargo.toml
@@ -15,6 +15,7 @@ curve25519-dalek = { version = "5", default-features = false }
 sha2 = { version = "0.11", default-features = false }
 hmac = { version = "0.13", default-features = false }
 aes = { version = "0.9", default-features = false }
+argon2 = { version = "0.5.3", default-features = false, features = ["alloc", "zeroize"] }
 pbkdf2 = { version = "0.13", default-features = false, features = ["hmac"] }
 getrandom = { version = "0.4", default-features = false, features = ["std"] }
 thistle-tk = { path = "../../crates/thistle-tk" }

--- a/components/kernel_rs/INTERFACES.md
+++ b/components/kernel_rs/INTERFACES.md
@@ -21,7 +21,7 @@ ThistleOS splits responsibility at the syscall boundary:
   C FFI functions declared in `thistle/kernel_rs.h`.
 
 The crate is `thistle-kernel` (version `0.1.0`). Current runtime dependencies:
-`log = "0.4"`, `ed25519-dalek`, `sha2`, `hmac`, `aes`, `pbkdf2`, `thistle-tk`,
+`log = "0.4"`, `ed25519-dalek`, `sha2`, `hmac`, `aes`, `argon2`, `pbkdf2`, `thistle-tk`,
 `embedded-graphics`. Build depends on `embuild = "0.33"` for ESP-IDF path
 discovery.
 
@@ -586,7 +586,8 @@ and `user_data` opaque pointers. All storage is in a `static Mutex<EventBus>`.
 
 Platform-independent cryptographic primitives with optional hardware acceleration
 via HAL dispatch. All symmetric crypto operations used by the kernel (AES-256-CBC
-encryption/decryption, HMAC-SHA256, SHA-256 hashing, PBKDF2 key derivation, and
+encryption/decryption, HMAC-SHA256, SHA-256 hashing, Argon2id key derivation,
+legacy PBKDF2 migration, and
 CSPRNG random bytes) are routed through this module. If a `hal_crypto_driver_t`
 vtable is registered (e.g. an ESP32-S3 hardware crypto driver), its functions are
 called first. If the vtable is absent or a particular operation is not implemented
@@ -653,6 +654,12 @@ esp_err_t thistle_crypto_pbkdf2_sha256(const uint8_t *password, size_t password_
                                        const uint8_t *salt, size_t salt_len,
                                        uint32_t iterations,
                                        uint8_t *out, size_t out_len);
+
+// Device-calibrated Argon2id v1.3 derivation. Salt must be 16 bytes and
+// output must be 32 bytes. Output is untouched on validation failure.
+esp_err_t thistle_crypto_argon2id(const uint8_t *password, size_t password_len,
+                                  const uint8_t salt[16], size_t salt_len,
+                                  uint8_t out[32], size_t out_len);
 
 // Fill `buf` with `len` bytes of cryptographically secure random data.
 esp_err_t thistle_crypto_random(uint8_t *buf, size_t len);

--- a/components/kernel_rs/src/crypto.rs
+++ b/components/kernel_rs/src/crypto.rs
@@ -15,6 +15,7 @@
 
 use std::os::raw::c_char;
 
+use argon2::{Algorithm, Argon2, Params, Version};
 use hmac::{Hmac, KeyInit as HmacKeyInit, Mac};
 use pbkdf2::pbkdf2_hmac;
 use sha2::{Sha256, Digest};
@@ -25,6 +26,13 @@ const ESP_OK: i32 = 0;
 const ESP_ERR_INVALID_ARG: i32 = 0x102;
 const ESP_ERR_INVALID_SIZE: i32 = 0x104;
 const ESP_FAIL: i32 = -1;
+
+pub const ARGON2ID_SALT_LEN: usize = 16;
+pub const ARGON2ID_KEY_LEN: usize = 32;
+pub const ARGON2ID_MAX_PASSWORD_LEN: usize = 1024;
+pub const ARGON2ID_MEMORY_KIB: u32 = 64;
+pub const ARGON2ID_TIME_COST: u32 = 6;
+pub const ARGON2ID_LANES: u32 = 1;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -83,8 +91,48 @@ fn sw_aes256_cbc_decrypt(key: &[u8; 32], iv: &[u8; 16], ct: &[u8], pt: &mut [u8]
     }
 }
 
-fn sw_random(buf: &mut [u8]) -> bool {
-    getrandom::fill(buf).is_ok()
+fn fill_random_result_with<F>(buf: &mut [u8], fill: F) -> i32
+where
+    F: FnOnce(&mut [u8]) -> i32,
+{
+    let result = fill(buf);
+    if result != ESP_OK {
+        buf.fill(0);
+    }
+    result
+}
+
+fn sw_random(buf: &mut [u8]) -> i32 {
+    fill_random_result_with(buf, |out| {
+        if getrandom::fill(out).is_ok() {
+            ESP_OK
+        } else {
+            ESP_FAIL
+        }
+    })
+}
+
+pub(crate) fn derive_argon2id_key(
+    password: &[u8],
+    salt: &[u8; ARGON2ID_SALT_LEN],
+) -> Result<[u8; ARGON2ID_KEY_LEN], i32> {
+    if password.is_empty() || password.len() > ARGON2ID_MAX_PASSWORD_LEN {
+        return Err(ESP_ERR_INVALID_ARG);
+    }
+
+    let params = Params::new(
+        ARGON2ID_MEMORY_KIB,
+        ARGON2ID_TIME_COST,
+        ARGON2ID_LANES,
+        Some(ARGON2ID_KEY_LEN),
+    )
+    .map_err(|_| ESP_ERR_INVALID_ARG)?;
+    let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+    let mut key = [0u8; ARGON2ID_KEY_LEN];
+    argon2
+        .hash_password_into(password, salt, &mut key)
+        .map_err(|_| ESP_FAIL)?;
+    Ok(key)
 }
 
 fn sw_aes128_ecb_encrypt_block(key: &[u8; 16], block_in: &[u8; 16], block_out: &mut [u8; 16]) {
@@ -233,18 +281,56 @@ pub unsafe extern "C" fn thistle_crypto_pbkdf2_sha256(
     ESP_OK
 }
 
+/// Derive a 256-bit key with the device-calibrated Argon2id v1.3 profile.
+///
+/// The output is left untouched when validation or derivation fails.
+#[no_mangle]
+pub unsafe extern "C" fn thistle_crypto_argon2id(
+    password: *const u8,
+    password_len: usize,
+    salt: *const u8,
+    salt_len: usize,
+    key_out: *mut u8,
+    key_len: usize,
+) -> i32 {
+    if password.is_null()
+        || salt.is_null()
+        || key_out.is_null()
+        || password_len == 0
+        || password_len > ARGON2ID_MAX_PASSWORD_LEN
+        || salt_len != ARGON2ID_SALT_LEN
+        || key_len != ARGON2ID_KEY_LEN
+    {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    let password = std::slice::from_raw_parts(password, password_len);
+    let salt = &*(salt as *const [u8; ARGON2ID_SALT_LEN]);
+    match derive_argon2id_key(password, salt) {
+        Ok(key) => {
+            std::ptr::copy_nonoverlapping(key.as_ptr(), key_out, ARGON2ID_KEY_LEN);
+            ESP_OK
+        }
+        Err(err) => err,
+    }
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn thistle_crypto_random(buf: *mut u8, len: usize) -> i32 {
     if buf.is_null() { return ESP_ERR_INVALID_ARG; }
 
     if let Some(hw) = get_hw_crypto() {
         if let Some(f) = hw.random {
-            return f(buf, len);
+            let result = f(buf, len);
+            if result != ESP_OK {
+                std::ptr::write_bytes(buf, 0, len);
+            }
+            return result;
         }
     }
 
     let slice = std::slice::from_raw_parts_mut(buf, len);
-    if sw_random(slice) { ESP_OK } else { ESP_FAIL }
+    sw_random(slice)
 }
 
 #[no_mangle]
@@ -481,6 +567,87 @@ mod tests {
         };
         assert_eq!(ret, ESP_OK);
         assert_ne!(key, [0u8; 32]);
+    }
+
+    #[test]
+    fn test_argon2id_ffi_uses_unique_salts() {
+        let password = b"correct horse battery staple";
+        let salt_a = [0x11u8; 16];
+        let salt_b = [0x22u8; 16];
+        let mut key_a = [0u8; 32];
+        let mut key_b = [0u8; 32];
+
+        let rc_a = unsafe {
+            thistle_crypto_argon2id(
+                password.as_ptr(),
+                password.len(),
+                salt_a.as_ptr(),
+                salt_a.len(),
+                key_a.as_mut_ptr(),
+                key_a.len(),
+            )
+        };
+        let rc_b = unsafe {
+            thistle_crypto_argon2id(
+                password.as_ptr(),
+                password.len(),
+                salt_b.as_ptr(),
+                salt_b.len(),
+                key_b.as_mut_ptr(),
+                key_b.len(),
+            )
+        };
+
+        assert_eq!(rc_a, ESP_OK);
+        assert_eq!(rc_b, ESP_OK);
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn test_argon2id_ffi_rejects_malformed_input_before_output() {
+        let password = b"passphrase";
+        let short_salt = [0x33u8; 8];
+        let mut key = [0xA5u8; 32];
+
+        let rc = unsafe {
+            thistle_crypto_argon2id(
+                password.as_ptr(),
+                password.len(),
+                short_salt.as_ptr(),
+                short_salt.len(),
+                key.as_mut_ptr(),
+                key.len(),
+            )
+        };
+
+        assert_eq!(rc, ESP_ERR_INVALID_ARG);
+        assert_eq!(key, [0xA5u8; 32]);
+
+        let valid_salt = [0x44u8; ARGON2ID_SALT_LEN];
+        let rc = unsafe {
+            thistle_crypto_argon2id(
+                password.as_ptr(),
+                ARGON2ID_MAX_PASSWORD_LEN + 1,
+                valid_salt.as_ptr(),
+                valid_salt.len(),
+                key.as_mut_ptr(),
+                key.len(),
+            )
+        };
+        assert_eq!(rc, ESP_ERR_INVALID_ARG);
+        assert_eq!(key, [0xA5u8; 32]);
+    }
+
+    #[test]
+    fn test_failed_random_fill_zeroes_partial_output() {
+        let mut output = [0xA5u8; 32];
+        let result = fill_random_result_with(&mut output, |buf| {
+            buf[..8].fill(0x5A);
+            ESP_FAIL
+        });
+
+        assert_eq!(result, ESP_FAIL);
+        assert_eq!(output, [0u8; 32]);
     }
 
     #[test]

--- a/components/kernel_rs/src/msg_crypto.rs
+++ b/components/kernel_rs/src/msg_crypto.rs
@@ -7,15 +7,15 @@
 // (encrypt-then-MAC) with per-message key derivation from a pre-computed
 // master key.
 //
-// Wire format: [version:1][nonce:16][ciphertext:N][hmac:32]
-// Total overhead: 49 bytes per message.
+// V2 wire format: [version:1][salt:16][nonce:16][ciphertext:N][hmac:32]
+// Total overhead: 65 bytes per message. Legacy v1 envelopes remain readable.
 
 use std::sync::Mutex;
 
 use aes::cipher::{BlockCipherEncrypt, KeyInit as AesKeyInit};
 use hmac::{Hmac, Mac};
 use pbkdf2::pbkdf2_hmac;
-use sha2::Sha256;
+use sha2::{Digest, Sha256};
 
 // ---------------------------------------------------------------------------
 // ESP-IDF error codes
@@ -36,12 +36,16 @@ const ESP_FAIL: i32 = -1;
 // ---------------------------------------------------------------------------
 
 const MAX_CHANNELS: usize = 32;
+const MAX_PASSPHRASE_LEN: usize = 256;
 const MASTER_KEY_LEN: usize = 32;
 const NONCE_LEN: usize = 16;
 const HMAC_LEN: usize = 32;
 const HEADER_LEN: usize = 1; // version byte
 const OVERHEAD: usize = HEADER_LEN + NONCE_LEN + HMAC_LEN; // 49 bytes
-const VERSION: u8 = 0x01;
+const V2_SALT_LEN: usize = 16;
+const V2_OVERHEAD: usize = HEADER_LEN + V2_SALT_LEN + NONCE_LEN + HMAC_LEN; // 65 bytes
+const LEGACY_VERSION: u8 = 0x01;
+const VERSION: u8 = 0x02;
 const PBKDF2_ITERATIONS: u32 = 10_000;
 const PBKDF2_SALT: &[u8] = b"ThistleOS-MsgCrypto-v1";
 
@@ -55,6 +59,9 @@ type HmacSha256 = Hmac<Sha256>;
 struct CryptoChannel {
     contact_id: u32,
     master_key: [u8; MASTER_KEY_LEN],
+    salt: [u8; V2_SALT_LEN],
+    password_material: [u8; MASTER_KEY_LEN],
+    legacy_master_key: [u8; MASTER_KEY_LEN],
     active: bool,
     msg_count_tx: u32,
     msg_count_rx: u32,
@@ -65,6 +72,9 @@ impl CryptoChannel {
         CryptoChannel {
             contact_id: 0,
             master_key: [0u8; MASTER_KEY_LEN],
+            salt: [0u8; V2_SALT_LEN],
+            password_material: [0u8; MASTER_KEY_LEN],
+            legacy_master_key: [0u8; MASTER_KEY_LEN],
             active: false,
             msg_count_tx: 0,
             msg_count_rx: 0,
@@ -216,10 +226,58 @@ fn derive_master_key(passphrase: &[u8]) -> [u8; MASTER_KEY_LEN] {
     key
 }
 
+fn prehash_passphrase(passphrase: &[u8]) -> [u8; MASTER_KEY_LEN] {
+    let mut hasher = Sha256::new();
+    hasher.update(b"ThistleOS-MsgCrypto-v2\0");
+    hasher.update(passphrase);
+    let digest = hasher.finalize();
+    let mut material = [0u8; MASTER_KEY_LEN];
+    material.copy_from_slice(&digest);
+    material
+}
+
+fn derive_v2_master_key(
+    password_material: &[u8; MASTER_KEY_LEN],
+    salt: &[u8; V2_SALT_LEN],
+) -> Result<[u8; MASTER_KEY_LEN], i32> {
+    crate::crypto::derive_argon2id_key(password_material, salt)
+}
+
+fn derive_v2_envelope_key_with<F>(
+    password_material: &[u8; MASTER_KEY_LEN],
+    input: &[u8],
+    derive: F,
+) -> Result<[u8; MASTER_KEY_LEN], i32>
+where
+    F: FnOnce(
+        &[u8; MASTER_KEY_LEN],
+        &[u8; V2_SALT_LEN],
+    ) -> Result<[u8; MASTER_KEY_LEN], i32>,
+{
+    if input.len() < V2_OVERHEAD {
+        return Err(ESP_ERR_INVALID_SIZE);
+    }
+    if input[0] != VERSION {
+        return Err(ESP_ERR_NOT_SUPPORTED);
+    }
+    let mut salt = [0u8; V2_SALT_LEN];
+    salt.copy_from_slice(&input[1..1 + V2_SALT_LEN]);
+    derive(password_material, &salt)
+}
+
 /// Zeroize channel key material before deactivation.
 fn zeroize_channel(ch: &mut CryptoChannel) {
     // Overwrite key material with zeros
     for byte in ch.master_key.iter_mut() {
+        *byte = 0;
+    }
+    for byte in ch.salt.iter_mut() {
+        *byte = 0;
+    }
+    for byte in ch.password_material.iter_mut() {
+        *byte = 0;
+    }
+    for byte in ch.legacy_master_key.iter_mut() {
         *byte = 0;
     }
     ch.active = false;
@@ -249,7 +307,7 @@ fn encrypt_message(
     let (enc_key, mac_key) = derive_per_message_keys(master_key, &nonce);
 
     // 3. Write version byte
-    output[0] = VERSION;
+    output[0] = LEGACY_VERSION;
 
     // 4. Write nonce
     output[1..1 + NONCE_LEN].copy_from_slice(&nonce);
@@ -278,7 +336,7 @@ fn decrypt_message(
     }
 
     // 2. Check version
-    if input[0] != VERSION {
+    if input[0] != LEGACY_VERSION {
         return Err(ESP_ERR_NOT_SUPPORTED);
     }
 
@@ -311,6 +369,75 @@ fn decrypt_message(
     Ok(ct_len)
 }
 
+/// Encrypt a v2 message. The random channel salt is carried in and
+/// authenticated by every envelope so the peer can derive the same key.
+fn encrypt_message_v2(
+    master_key: &[u8; MASTER_KEY_LEN],
+    salt: &[u8; V2_SALT_LEN],
+    plaintext: &[u8],
+    output: &mut [u8],
+) -> Result<usize, i32> {
+    let total_len = V2_OVERHEAD + plaintext.len();
+    if output.len() < total_len {
+        return Err(ESP_ERR_NO_MEM);
+    }
+
+    let mut nonce = [0u8; NONCE_LEN];
+    if getrandom::fill(&mut nonce).is_err() {
+        return Err(ESP_FAIL);
+    }
+
+    output[0] = VERSION;
+    output[1..1 + V2_SALT_LEN].copy_from_slice(salt);
+    let nonce_start = HEADER_LEN + V2_SALT_LEN;
+    output[nonce_start..nonce_start + NONCE_LEN].copy_from_slice(&nonce);
+
+    let (enc_key, mac_key) = derive_per_message_keys(master_key, &nonce);
+    let ct_start = nonce_start + NONCE_LEN;
+    let ct_end = ct_start + plaintext.len();
+    aes256_ctr_process(&enc_key, &nonce, plaintext, &mut output[ct_start..ct_end]);
+    let hmac_val = compute_hmac(&mac_key, &output[..ct_end]);
+    output[ct_end..ct_end + HMAC_LEN].copy_from_slice(&hmac_val);
+    Ok(total_len)
+}
+
+fn decrypt_message_v2(
+    master_key: &[u8; MASTER_KEY_LEN],
+    input: &[u8],
+    plaintext: &mut [u8],
+) -> Result<usize, i32> {
+    if input.len() < V2_OVERHEAD {
+        return Err(ESP_ERR_INVALID_SIZE);
+    }
+    if input[0] != VERSION {
+        return Err(ESP_ERR_NOT_SUPPORTED);
+    }
+
+    let nonce_start = HEADER_LEN + V2_SALT_LEN;
+    let nonce: [u8; NONCE_LEN] = input[nonce_start..nonce_start + NONCE_LEN]
+        .try_into()
+        .map_err(|_| ESP_ERR_INVALID_SIZE)?;
+    let ct_len = input.len() - V2_OVERHEAD;
+    let ct_start = nonce_start + NONCE_LEN;
+    let ct_end = ct_start + ct_len;
+    if plaintext.len() < ct_len {
+        return Err(ESP_ERR_NO_MEM);
+    }
+
+    let (enc_key, mac_key) = derive_per_message_keys(master_key, &nonce);
+    let computed_hmac = compute_hmac(&mac_key, &input[..ct_end]);
+    if !constant_time_eq(&computed_hmac, &input[ct_end..ct_end + HMAC_LEN]) {
+        return Err(ESP_ERR_INVALID_CRC);
+    }
+    aes256_ctr_process(
+        &enc_key,
+        &nonce,
+        &input[ct_start..ct_end],
+        &mut plaintext[..ct_len],
+    );
+    Ok(ct_len)
+}
+
 // ---------------------------------------------------------------------------
 // FFI exports
 // ---------------------------------------------------------------------------
@@ -335,7 +462,10 @@ pub unsafe extern "C" fn rs_msg_crypto_establish(
     passphrase: *const u8,
     passphrase_len: usize,
 ) -> i32 {
-    if passphrase.is_null() || passphrase_len == 0 {
+    if passphrase.is_null()
+        || passphrase_len == 0
+        || passphrase_len > MAX_PASSPHRASE_LEN
+    {
         return ESP_ERR_INVALID_ARG;
     }
 
@@ -346,7 +476,16 @@ pub unsafe extern "C" fn rs_msg_crypto_establish(
 
     // SAFETY: Caller guarantees passphrase points to passphrase_len valid bytes.
     let pw = std::slice::from_raw_parts(passphrase, passphrase_len);
-    let master_key = derive_master_key(pw);
+    let password_material = prehash_passphrase(pw);
+    let legacy_master_key = derive_master_key(pw);
+    let mut salt = [0u8; V2_SALT_LEN];
+    if getrandom::fill(&mut salt).is_err() {
+        return ESP_FAIL;
+    }
+    let master_key = match derive_v2_master_key(&password_material, &salt) {
+        Ok(key) => key,
+        Err(err) => return err,
+    };
 
     // Check if channel already exists — replace it
     let slot = if let Some(idx) = state.find_channel(contact_id) {
@@ -363,6 +502,9 @@ pub unsafe extern "C" fn rs_msg_crypto_establish(
     state.channels[slot] = CryptoChannel {
         contact_id,
         master_key,
+        salt,
+        password_material,
+        legacy_master_key,
         active: true,
         msg_count_tx: 0,
         msg_count_rx: 0,
@@ -440,6 +582,7 @@ pub unsafe extern "C" fn rs_msg_crypto_encrypt(
     };
 
     let master_key = state.channels[idx].master_key;
+    let salt = state.channels[idx].salt;
 
     // SAFETY: Caller guarantees pointers are valid for the given lengths.
     let pt = if pt_len > 0 {
@@ -449,7 +592,7 @@ pub unsafe extern "C" fn rs_msg_crypto_encrypt(
     };
     let ct = std::slice::from_raw_parts_mut(ciphertext, ct_max);
 
-    match encrypt_message(&master_key, pt, ct) {
+    match encrypt_message_v2(&master_key, &salt, pt, ct) {
         Ok(len) => {
             state.channels[idx].msg_count_tx += 1;
             len as i32
@@ -481,13 +624,25 @@ pub unsafe extern "C" fn rs_msg_crypto_decrypt(
         None => return ESP_ERR_NOT_FOUND,
     };
 
-    let master_key = state.channels[idx].master_key;
-
     // SAFETY: Caller guarantees pointers are valid for the given lengths.
     let ct = std::slice::from_raw_parts(ciphertext, ct_len);
     let pt = std::slice::from_raw_parts_mut(plaintext, pt_max);
 
-    match decrypt_message(&master_key, ct, pt) {
+    let result = match ct.first().copied() {
+        Some(LEGACY_VERSION) => {
+            let legacy_master_key = state.channels[idx].legacy_master_key;
+            decrypt_message(&legacy_master_key, ct, pt)
+        }
+        Some(VERSION) => {
+            let password_material = state.channels[idx].password_material;
+            derive_v2_envelope_key_with(&password_material, ct, derive_v2_master_key)
+                .and_then(|master_key| decrypt_message_v2(&master_key, ct, pt))
+        }
+        Some(_) => Err(ESP_ERR_NOT_SUPPORTED),
+        None => Err(ESP_ERR_INVALID_SIZE),
+    };
+
+    match result {
         Ok(len) => {
             state.channels[idx].msg_count_rx += 1;
             len as i32
@@ -496,10 +651,10 @@ pub unsafe extern "C" fn rs_msg_crypto_decrypt(
     }
 }
 
-/// Returns the per-message overhead in bytes (49).
+/// Returns the v2 per-message overhead in bytes (65).
 #[no_mangle]
 pub extern "C" fn rs_msg_crypto_get_overhead() -> i32 {
-    OVERHEAD as i32
+    V2_OVERHEAD as i32
 }
 
 /// Returns the number of active encrypted channels.
@@ -559,22 +714,53 @@ pub unsafe extern "C" fn rs_msg_crypto_get_stats(out: *mut CMsgCryptoStats) -> i
     ESP_OK
 }
 
-/// Standalone PBKDF2 key derivation utility. Writes 32 bytes to key_out.
+/// Retained ABI entry point for old callers. Insecure unsalted derivation is
+/// disabled; callers must migrate to `rs_msg_crypto_derive_key_v2`.
 #[no_mangle]
 pub unsafe extern "C" fn rs_msg_crypto_derive_key(
     passphrase: *const u8,
     pw_len: usize,
     key_out: *mut u8,
 ) -> i32 {
-    if passphrase.is_null() || key_out.is_null() || pw_len == 0 {
+    if passphrase.is_null()
+        || key_out.is_null()
+        || pw_len == 0
+        || pw_len > MAX_PASSPHRASE_LEN
+    {
         return ESP_ERR_INVALID_ARG;
     }
 
-    // SAFETY: Caller guarantees pointers are valid for the given lengths.
+    ESP_ERR_NOT_SUPPORTED
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_msg_crypto_derive_key_v2(
+    passphrase: *const u8,
+    pw_len: usize,
+    salt: *const u8,
+    salt_len: usize,
+    key_out: *mut u8,
+) -> i32 {
+    if passphrase.is_null()
+        || salt.is_null()
+        || key_out.is_null()
+        || pw_len == 0
+        || pw_len > MAX_PASSPHRASE_LEN
+        || salt_len != V2_SALT_LEN
+    {
+        return ESP_ERR_INVALID_ARG;
+    }
+
     let pw = std::slice::from_raw_parts(passphrase, pw_len);
-    let key = derive_master_key(pw);
-    std::ptr::copy_nonoverlapping(key.as_ptr(), key_out, MASTER_KEY_LEN);
-    ESP_OK
+    let salt = &*(salt as *const [u8; V2_SALT_LEN]);
+    let password_material = prehash_passphrase(pw);
+    match derive_v2_master_key(&password_material, salt) {
+        Ok(key) => {
+            std::ptr::copy_nonoverlapping(key.as_ptr(), key_out, MASTER_KEY_LEN);
+            ESP_OK
+        }
+        Err(err) => err,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -649,6 +835,32 @@ mod tests {
         // Should still have only 1 channel
         assert_eq!(unsafe { rs_msg_crypto_channel_count() }, 1);
         assert!(unsafe { rs_msg_crypto_is_active(10) });
+    }
+
+    #[test]
+    fn test_reestablish_generates_a_fresh_v2_salt() {
+        reset_state();
+        unsafe { rs_msg_crypto_init() };
+        let pw = b"shared passphrase";
+        assert_eq!(
+            unsafe { rs_msg_crypto_establish(77, pw.as_ptr(), pw.len()) },
+            ESP_OK
+        );
+        let first_salt = {
+            let state = STATE.lock().unwrap();
+            state.channels[state.find_channel(77).unwrap()].salt
+        };
+
+        assert_eq!(
+            unsafe { rs_msg_crypto_establish(77, pw.as_ptr(), pw.len()) },
+            ESP_OK
+        );
+        let second_salt = {
+            let state = STATE.lock().unwrap();
+            state.channels[state.find_channel(77).unwrap()].salt
+        };
+
+        assert_ne!(first_salt, second_salt);
     }
 
     #[test]
@@ -824,6 +1036,62 @@ mod tests {
         let k1 = derive_master_key(b"alpha");
         let k2 = derive_master_key(b"bravo");
         assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn test_v2_master_key_changes_with_random_salt() {
+        let password_material = prehash_passphrase(b"shared passphrase");
+        let key_a = derive_v2_master_key(&password_material, &[0x41; 16]).unwrap();
+        let key_b = derive_v2_master_key(&password_material, &[0x42; 16]).unwrap();
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn test_v2_envelope_authenticates_its_salt() {
+        let password_material = prehash_passphrase(b"shared passphrase");
+        let salt = [0x51; 16];
+        let key = derive_v2_master_key(&password_material, &salt).unwrap();
+        let plaintext = b"authenticated salt";
+        let mut encrypted = vec![0u8; plaintext.len() + V2_OVERHEAD];
+        let len = encrypt_message_v2(&key, &salt, plaintext, &mut encrypted).unwrap();
+
+        encrypted[1] ^= 0x01;
+        let tampered_salt: [u8; 16] = encrypted[1..17].try_into().unwrap();
+        let tampered_key = derive_v2_master_key(&password_material, &tampered_salt).unwrap();
+        let mut decrypted = vec![0u8; plaintext.len()];
+        assert_eq!(
+            decrypt_message_v2(&tampered_key, &encrypted[..len], &mut decrypted),
+            Err(ESP_ERR_INVALID_CRC)
+        );
+    }
+
+    #[test]
+    fn test_malformed_v2_envelope_is_rejected_before_kdf() {
+        let password_material = prehash_passphrase(b"shared passphrase");
+        let mut derive_calls = 0;
+        let result = derive_v2_envelope_key_with(
+            &password_material,
+            &[VERSION; V2_OVERHEAD - 1],
+            |_, _| {
+                derive_calls += 1;
+                Ok([0u8; MASTER_KEY_LEN])
+            },
+        );
+        assert_eq!(result, Err(ESP_ERR_INVALID_SIZE));
+        assert_eq!(derive_calls, 0);
+
+        let mut wrong_version = [0u8; V2_OVERHEAD];
+        wrong_version[0] = 0xFF;
+        let result = derive_v2_envelope_key_with(
+            &password_material,
+            &wrong_version,
+            |_, _| {
+                derive_calls += 1;
+                Ok([0u8; MASTER_KEY_LEN])
+            },
+        );
+        assert_eq!(result, Err(ESP_ERR_NOT_SUPPORTED));
+        assert_eq!(derive_calls, 0);
     }
 
     // ── Per-message key derivation ───────────────────────────────────
@@ -1210,11 +1478,11 @@ mod tests {
         let pw = b"empty-msg-test";
         unsafe { rs_msg_crypto_establish(1, pw.as_ptr(), pw.len()) };
 
-        let mut ct = [0u8; OVERHEAD + 16]; // extra space
+        let mut ct = [0u8; V2_OVERHEAD + 16]; // extra space
         let enc_len = unsafe {
             rs_msg_crypto_encrypt(1, [].as_ptr(), 0, ct.as_mut_ptr(), ct.len())
         };
-        assert_eq!(enc_len, OVERHEAD as i32);
+        assert_eq!(enc_len, V2_OVERHEAD as i32);
 
         let mut pt = [0u8; 16];
         let dec_len = unsafe {
@@ -1239,7 +1507,7 @@ mod tests {
 
     #[test]
     fn test_overhead_constant() {
-        assert_eq!(rs_msg_crypto_get_overhead(), 49);
+        assert_eq!(rs_msg_crypto_get_overhead(), V2_OVERHEAD as i32);
         assert_eq!(OVERHEAD, 49);
         assert_eq!(HEADER_LEN + NONCE_LEN + HMAC_LEN, 49);
     }
@@ -1247,32 +1515,49 @@ mod tests {
     // ── FFI derive key utility ───────────────────────────────────────
 
     #[test]
-    fn test_derive_key_ffi() {
+    fn test_derive_key_v2_ffi() {
         let pw = b"ffi-derivation";
+        let salt = [0x61u8; V2_SALT_LEN];
         let mut key1 = [0u8; 32];
         let mut key2 = [0u8; 32];
         let ret = unsafe {
-            rs_msg_crypto_derive_key(pw.as_ptr(), pw.len(), key1.as_mut_ptr())
+            rs_msg_crypto_derive_key_v2(
+                pw.as_ptr(), pw.len(), salt.as_ptr(), salt.len(), key1.as_mut_ptr()
+            )
         };
         assert_eq!(ret, ESP_OK);
         assert_ne!(key1, [0u8; 32]);
 
         // Same passphrase produces same key
         unsafe {
-            rs_msg_crypto_derive_key(pw.as_ptr(), pw.len(), key2.as_mut_ptr());
+            rs_msg_crypto_derive_key_v2(
+                pw.as_ptr(), pw.len(), salt.as_ptr(), salt.len(), key2.as_mut_ptr()
+            );
         }
         assert_eq!(key1, key2);
     }
 
     #[test]
-    fn test_derive_key_matches_internal() {
+    fn test_derive_key_v2_matches_internal() {
         let pw = b"consistency-check";
-        let internal = derive_master_key(pw);
+        let salt = [0x62u8; V2_SALT_LEN];
+        let internal = derive_v2_master_key(&prehash_passphrase(pw), &salt).unwrap();
         let mut ffi_key = [0u8; 32];
         unsafe {
-            rs_msg_crypto_derive_key(pw.as_ptr(), pw.len(), ffi_key.as_mut_ptr());
+            rs_msg_crypto_derive_key_v2(
+                pw.as_ptr(), pw.len(), salt.as_ptr(), salt.len(), ffi_key.as_mut_ptr()
+            );
         }
         assert_eq!(ffi_key, internal);
+    }
+
+    #[test]
+    fn test_legacy_derive_key_api_fails_closed() {
+        let pw = b"legacy";
+        let mut output = [0xA5u8; MASTER_KEY_LEN];
+        let ret = unsafe { rs_msg_crypto_derive_key(pw.as_ptr(), pw.len(), output.as_mut_ptr()) };
+        assert_eq!(ret, ESP_ERR_NOT_SUPPORTED);
+        assert_eq!(output, [0xA5u8; MASTER_KEY_LEN]);
     }
 
     // ── Uninitialized state ──────────────────────────────────────────

--- a/components/kernel_rs/src/syscall_table.rs
+++ b/components/kernel_rs/src/syscall_table.rs
@@ -52,6 +52,7 @@ const APP_VISIBLE_SYMBOLS: &[&str] = &[
     "thistle_crypto_aes128_ecb_encrypt",
     "thistle_crypto_aes256_cbc_decrypt",
     "thistle_crypto_aes256_cbc_encrypt",
+    "thistle_crypto_argon2id",
     "thistle_crypto_ed25519_derive_public",
     "thistle_crypto_ed25519_keygen",
     "thistle_crypto_ed25519_sign",
@@ -425,6 +426,7 @@ extern "C" {
     fn thistle_crypto_hmac_verify(key: *const u8, key_len: usize, data: *const u8, data_len: usize, expected_mac: *const u8) -> i32;
     fn thistle_crypto_aes256_cbc_encrypt(key: *const u8, iv: *const u8, plaintext: *const u8, len: usize, ciphertext_out: *mut u8) -> i32;
     fn thistle_crypto_aes256_cbc_decrypt(key: *const u8, iv: *const u8, ciphertext: *const u8, len: usize, plaintext_out: *mut u8) -> i32;
+    fn thistle_crypto_argon2id(password: *const u8, password_len: usize, salt: *const u8, salt_len: usize, key_out: *mut u8, key_len: usize) -> i32;
     fn thistle_crypto_pbkdf2_sha256(password: *const c_char, salt: *const u8, salt_len: usize, iterations: u32, key_out: *mut u8, key_len: usize) -> i32;
     fn thistle_crypto_random(buf: *mut u8, len: usize) -> i32;
     fn thistle_crypto_aes128_ecb_encrypt(key: *const u8, plaintext: *const u8, len: usize, ciphertext_out: *mut u8) -> i32;
@@ -987,6 +989,7 @@ static SYSCALL_TABLE: &[SyscallEntry] = &[
     entry!("thistle_crypto_aes128_ecb_encrypt", thistle_crypto_aes128_ecb_encrypt as unsafe extern "C" fn(*const u8, *const u8, usize, *mut u8) -> i32),
     entry!("thistle_crypto_aes256_cbc_decrypt", thistle_crypto_aes256_cbc_decrypt as unsafe extern "C" fn(*const u8, *const u8, *const u8, usize, *mut u8) -> i32),
     entry!("thistle_crypto_aes256_cbc_encrypt", thistle_crypto_aes256_cbc_encrypt as unsafe extern "C" fn(*const u8, *const u8, *const u8, usize, *mut u8) -> i32),
+    entry!("thistle_crypto_argon2id",          thistle_crypto_argon2id          as unsafe extern "C" fn(*const u8, usize, *const u8, usize, *mut u8, usize) -> i32),
     entry!("thistle_crypto_ed25519_derive_public", thistle_crypto_ed25519_derive_public as unsafe extern "C" fn(*const u8, *mut u8) -> i32),
     entry!("thistle_crypto_ed25519_keygen",       thistle_crypto_ed25519_keygen       as unsafe extern "C" fn(*mut u8, *mut u8) -> i32),
     entry!("thistle_crypto_ed25519_sign",         thistle_crypto_ed25519_sign         as unsafe extern "C" fn(*const u8, *const u8, usize, *mut u8) -> i32),
@@ -1098,6 +1101,7 @@ static SYSCALL_TABLE: &[SyscallEntry] = &[
     entry!("thistle_crypto_aes128_ecb_encrypt", thistle_crypto_aes128_ecb_encrypt as unsafe extern "C" fn(*const u8, *const u8, usize, *mut u8) -> i32),
     entry!("thistle_crypto_aes256_cbc_decrypt", thistle_crypto_aes256_cbc_decrypt as unsafe extern "C" fn(*const u8, *const u8, *const u8, usize, *mut u8) -> i32),
     entry!("thistle_crypto_aes256_cbc_encrypt", thistle_crypto_aes256_cbc_encrypt as unsafe extern "C" fn(*const u8, *const u8, *const u8, usize, *mut u8) -> i32),
+    entry!("thistle_crypto_argon2id",          thistle_crypto_argon2id          as unsafe extern "C" fn(*const u8, usize, *const u8, usize, *mut u8, usize) -> i32),
     entry!("thistle_crypto_ed25519_derive_public", thistle_crypto_ed25519_derive_public as unsafe extern "C" fn(*const u8, *mut u8) -> i32),
     entry!("thistle_crypto_ed25519_keygen",       thistle_crypto_ed25519_keygen       as unsafe extern "C" fn(*mut u8, *mut u8) -> i32),
     entry!("thistle_crypto_ed25519_sign",         thistle_crypto_ed25519_sign         as unsafe extern "C" fn(*const u8, *const u8, usize, *mut u8) -> i32),

--- a/docs/kernel-modules.html
+++ b/docs/kernel-modules.html
@@ -148,12 +148,12 @@
 <span class="tok-keyword">pub</span> <span class="tok-keyword">extern</span> <span class="tok-string">"C"</span> <span class="tok-keyword">fn</span> <span class="tok-fn">rs_msg_queue_set_defaults</span>(max_retries: <span class="tok-type">u32</span>, ttl_ms: <span class="tok-type">u64</span>) -> <span class="tok-type">i32</span>;</code></pre>
 
     <h3>Message Crypto</h3>
-    <p><code>msg_crypto.rs</code> — End-to-end message encryption using AES-256-CTR + HMAC-SHA256. PBKDF2 key derivation from shared secrets. Per-message nonces with only 49 bytes overhead per encrypted message.</p>
+    <p><code>msg_crypto.rs</code> — End-to-end message encryption using AES-256-CTR + HMAC-SHA256. Versioned Argon2id key derivation uses authenticated random salts; legacy v1 envelopes remain readable during migration. V2 adds 65 bytes overhead per encrypted message.</p>
     <ul>
       <li>AES-256-CTR encryption with HMAC-SHA256 authentication</li>
-      <li>PBKDF2 key derivation from shared secrets</li>
+      <li>Argon2id key derivation from shared secrets with per-channel random salts</li>
       <li>Per-message unique nonces</li>
-      <li>49 bytes overhead per encrypted message</li>
+      <li>65 bytes overhead per v2 encrypted message</li>
       <li>Per-contact crypto channels with session statistics</li>
     </ul>
     <p><span class="badge badge-purple">12 FFI exports</span> <span class="badge badge-green">48 tests</span></p>

--- a/docs/security.html
+++ b/docs/security.html
@@ -169,9 +169,9 @@ thistle-register-key --port /dev/ttyACM0 --key dev_key.bin</code></pre>
     <p>The built-in settings app includes a password vault. Vault entries are encrypted at rest on the SD card using:</p>
 
     <ul>
-      <li><strong>Key derivation:</strong> PBKDF2-HMAC-SHA256 with 100,000 iterations and a random 16-byte salt stored alongside the ciphertext</li>
+      <li><strong>Key derivation:</strong> Argon2id v1.3 with a random 16-byte salt and versioned, authenticated parameters</li>
       <li><strong>Encryption:</strong> AES-256-CBC with a random IV per entry</li>
-      <li><strong>Storage:</strong> <code>/sdcard/data/vault.enc</code></li>
+      <li><strong>Storage:</strong> <code>/sdcard/config/vault.enc</code>, with automatic authenticated migration from legacy PBKDF2 files</li>
     </ul>
 
     <p>The master password is never stored — only the derived key is used for encryption/decryption and is held in DRAM only while the vault app is open. Closing the vault app zeroes the in-memory key.</p>

--- a/docs/security/password-kdf-migration.md
+++ b/docs/security/password-kdf-migration.md
@@ -1,0 +1,59 @@
+# Password KDF and envelope migration
+
+ThistleOS uses a versioned Argon2id profile for new password-derived keys:
+
+- Argon2id v1.3
+- 64 KiB memory
+- 6 iterations
+- 1 lane
+- 16-byte cryptographically random salt
+- 32-byte derived key
+
+Password inputs are bounded before the KDF reads them (128 characters in the
+vault UI, 256 bytes for messaging, and 1,024 bytes in the generic crypto ABI).
+Random-generation failures abort vault creation or saving, and any partially
+filled random output is zeroed before the error is returned.
+
+The 64 KiB profile is the common baseline calibrated for the lowest-memory
+supported ESP32-family targets, including boards without PSRAM. The parameters
+are stored in each vault envelope so a future release can introduce a stronger
+profile without guessing how an existing file was derived. Unsupported or
+malformed parameters fail closed before key derivation or decryption.
+
+## Vault files
+
+New vaults use the authenticated `THV2` envelope:
+
+```
+magic(4) | version(1) | kdf(1) | reserved(2)
+memory_kib(4) | time_cost(4) | lanes(4)
+salt(16) | iv(16) | ciphertext(n) | hmac_sha256(32)
+```
+
+All numeric fields are little-endian. The HMAC covers the entire header and
+ciphertext, including the KDF parameters and salt.
+
+Legacy vaults have no magic and use the old 10,000-iteration PBKDF2 layout.
+They are accepted only as a migration source. After successful authentication
+and decryption, the vault generates a new random salt and rewrites the data as
+v2. The rewrite uses a temporary file and recoverable backup; an interrupted or
+failed rewrite retains the original vault and does not report a successful
+unlock.
+
+## Messaging
+
+New encrypted messages use wire version 2:
+
+```
+version(1) | salt(16) | nonce(16) | ciphertext(n) | hmac_sha256(32)
+```
+
+Each channel receives a fresh random salt. The salt is included in the
+authenticated envelope so both peers derive the same Argon2id key. Version 1
+messages remain decryptable with the legacy key during migration, but all new
+encryption emits version 2. The old unsalted standalone derivation API now
+fails closed; callers must provide a 16-byte salt to the v2 API.
+
+Changing a shared passphrase re-establishes the channel with a new random salt.
+Destroying or replacing a channel zeroes its v2 key, salt, password material,
+and legacy migration key.


### PR DESCRIPTION
## What changed

- add a device-calibrated Argon2id v1.3 KDF to the Rust crypto service and app ABI
- migrate vault files to an authenticated, versioned `THV2` envelope with stored KDF parameters and unique random salts
- abort vault creation/saving on RNG failure and zero any partially filled random output
- authenticate and decrypt legacy PBKDF2 vaults once, then re-key them through a recoverable temporary/backup replacement
- emit messaging wire v2 with authenticated per-channel random salts while retaining v1 decryption during transition
- disable the old unsalted standalone messaging derivation API and add a salt-required v2 replacement
- document the envelope formats, migration behavior, parameters, and licensing

## Why

Vault and messaging passphrases were derived with only 10,000 PBKDF2-SHA256 iterations, and messaging used a fixed global salt. That made captured ciphertext materially easier to attack offline and provided no safe format evolution path.

The new versioned envelopes bind random salts and KDF metadata to the HMAC. Malformed or unsupported state is rejected before expensive derivation/decryption, failed first-use persistence does not unlock the vault, and interrupted legacy rewrites preserve a recoverable original.

## Impact

- existing vaults migrate automatically after the first successful unlock
- new messaging ciphertext has 65 bytes of overhead instead of 49
- legacy v1 messages remain decryptable, but all new encryption emits v2
- H2 is not part of the validation matrix because support was previously descoped

## Validation

- regression tests first failed on the missing Argon2id and v2 envelope paths
- 1,332 Rust host tests passed serially, including a fault-injected partial RNG failure
- focused crypto and messaging suites passed
- `cargo +esp check` passed for `esp32`, `esp32s2`, `esp32s3`, `esp32c3`, and `esp32c6` feature configurations
- Recovery `cargo +esp check` passed
- full ESP-IDF 5.5 ESP32-S3 firmware build and link passed; image fits with 12% free in the smallest app partition
- simulator Rust kernel and simulator test binary built; the GUI target remains blocked by its existing missing LVGL setup in a fresh worktree
- `git diff --check` passed

Closes #70
Closes #76
