### PR TITLE
Bind driver verification to the relocated byte snapshot

### DIFF
--- a/components/kernel_rs/src/driver_loader.rs
+++ b/components/kernel_rs/src/driver_loader.rs
@@ -6,6 +6,7 @@
 // verifies signatures, parses manifests, and calls driver_init().
 
 use std::ffi::CStr;
+use std::io::Read;
 use std::os::raw::{c_char, c_int, c_void};
 use std::sync::Mutex;
 
@@ -42,9 +43,6 @@ extern "C" {
     // PSRAM allocation
     fn heap_caps_malloc(size: usize, caps: u32) -> *mut c_void;
     fn free(ptr: *mut c_void);
-
-    // Signing (Rust)
-    fn signing_verify_file(path: *const c_char) -> i32;
 
     // Manifest (C/Rust shims)
     fn manifest_parse_file(path: *const c_char, out: *mut CManifest) -> i32;
@@ -275,6 +273,43 @@ fn driver_signature_allows_load(signature_result: i32) -> Result<bool, i32> {
     Err(signature_result)
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum PrepareDriverImageError {
+    Read(i32),
+    InvalidSize,
+    Verify(i32),
+}
+
+fn prepare_driver_image_with(
+    path: &str,
+    read_image: impl FnOnce(&str) -> Result<Vec<u8>, i32>,
+    verify_image: impl FnOnce(&str, &[u8]) -> i32,
+) -> Result<(Vec<u8>, bool), PrepareDriverImageError> {
+    let image = read_image(path).map_err(PrepareDriverImageError::Read)?;
+    if image.is_empty() || image.len() > MAX_DRV_SIZE {
+        return Err(PrepareDriverImageError::InvalidSize);
+    }
+
+    let signature_verified = driver_signature_allows_load(verify_image(path, &image))
+        .map_err(PrepareDriverImageError::Verify)?;
+    Ok((image, signature_verified))
+}
+
+fn prepare_driver_image(path: &str) -> Result<(Vec<u8>, bool), PrepareDriverImageError> {
+    prepare_driver_image_with(
+        path,
+        |path| {
+            let file = std::fs::File::open(path).map_err(|_| ESP_ERR_NOT_FOUND)?;
+            let mut image = Vec::new();
+            file.take((MAX_DRV_SIZE + 1) as u64)
+                .read_to_end(&mut image)
+                .map_err(|_| ESP_FAIL)?;
+            Ok(image)
+        },
+        crate::signing::verify_file_bytes,
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Symbol resolver — delegates to the kernel syscall table
 // ---------------------------------------------------------------------------
@@ -342,7 +377,7 @@ pub extern "C" fn driver_loader_get_config() -> *const c_char {
 
 /// Load a driver ELF from `path`.
 ///
-/// Steps: verify signature, parse manifest, read ELF into PSRAM, relocate,
+/// Steps: read and verify one ELF snapshot, parse manifest, copy to PSRAM, relocate,
 /// call driver_init() entry point.
 ///
 /// # Safety
@@ -388,25 +423,28 @@ pub unsafe extern "C" fn driver_loader_load(path: *const c_char) -> i32 {
         return ret;
     }
 
-    // 1. Verify signature
-    match driver_signature_allows_load(signing_verify_file(path)) {
-        Ok(true) => {
+    // 1. Read once and verify the exact byte snapshot that will be relocated.
+    let (file_data, signature_verified) = match prepare_driver_image(path_str) {
+        Ok(prepared) => prepared,
+        Err(PrepareDriverImageError::Read(err)) => {
             esp_log_write(
-                ESP_LOG_INFO,
+                ESP_LOG_ERROR,
                 TAG.as_ptr(),
-                b"Driver signature verified: %s\0".as_ptr(),
+                b"Cannot open driver ELF: %s\0".as_ptr(),
                 path,
             );
+            return err;
         }
-        Ok(false) => {
+        Err(PrepareDriverImageError::InvalidSize) => {
             esp_log_write(
-                ESP_LOG_WARN,
+                ESP_LOG_ERROR,
                 TAG.as_ptr(),
-                b"Driver unsigned (dev mode): %s\0".as_ptr(),
+                b"Rejecting driver size: %s\0".as_ptr(),
                 path,
             );
+            return ESP_ERR_INVALID_SIZE;
         }
-        Err(err) => {
+        Err(PrepareDriverImageError::Verify(err)) => {
             esp_log_write(
                 ESP_LOG_ERROR,
                 TAG.as_ptr(),
@@ -416,6 +454,22 @@ pub unsafe extern "C" fn driver_loader_load(path: *const c_char) -> i32 {
             );
             return err;
         }
+    };
+
+    if signature_verified {
+        esp_log_write(
+            ESP_LOG_INFO,
+            TAG.as_ptr(),
+            b"Driver signature verified: %s\0".as_ptr(),
+            path,
+        );
+    } else {
+        esp_log_write(
+            ESP_LOG_WARN,
+            TAG.as_ptr(),
+            b"Driver unsigned (dev mode): %s\0".as_ptr(),
+            path,
+        );
     }
 
     // 2. Parse manifest (optional)
@@ -446,27 +500,8 @@ pub unsafe extern "C" fn driver_loader_load(path: *const c_char) -> i32 {
         }
     }
 
-    // 3. Read ELF file into PSRAM
-    let file_data = match std::fs::read(path_str) {
-        Ok(d) => d,
-        Err(_) => {
-            esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"Cannot open driver ELF: %s\0".as_ptr(), path);
-            return ESP_ERR_NOT_FOUND;
-        }
-    };
-
+    // 3. Copy the already-verified snapshot into PSRAM.
     let size = file_data.len();
-    if size == 0 || size > MAX_DRV_SIZE {
-        esp_log_write(
-            ESP_LOG_ERROR,
-            TAG.as_ptr(),
-            b"Rejecting driver size %d: %s\0".as_ptr(),
-            size as c_int,
-            path,
-        );
-        return ESP_ERR_INVALID_SIZE;
-    }
-
     let buf = heap_caps_malloc(size, MALLOC_CAP_SPIRAM);
     if buf.is_null() {
         esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"PSRAM alloc failed for driver: %s\0".as_ptr(), path);
@@ -656,7 +691,9 @@ pub unsafe extern "C" fn driver_loader_load_with_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
     use std::ffi::CStr;
+    use std::rc::Rc;
 
     fn reset_state() {
         if let Ok(mut s) = STATE.lock() {
@@ -749,5 +786,66 @@ mod tests {
         ] {
             assert_eq!(driver_signature_allows_load(error), Err(error));
         }
+    }
+
+    #[test]
+    fn test_prepared_driver_image_is_the_exact_verified_snapshot() {
+        let trusted = b"trusted driver bytes".to_vec();
+        let attacker = b"swapped attacker bytes".to_vec();
+        let on_disk = Rc::new(RefCell::new(trusted.clone()));
+        let verified = Rc::new(RefCell::new(Vec::new()));
+
+        let read_disk = Rc::clone(&on_disk);
+        let verify_disk = Rc::clone(&on_disk);
+        let verify_capture = Rc::clone(&verified);
+        let prepared = prepare_driver_image_with(
+            "/sdcard/drivers/test.drv.elf",
+            move |_| Ok(read_disk.borrow().clone()),
+            move |_, image| {
+                verify_capture.borrow_mut().extend_from_slice(image);
+                *verify_disk.borrow_mut() = attacker;
+                ESP_OK
+            },
+        )
+        .expect("the trusted snapshot should pass verification");
+
+        assert_eq!(*verified.borrow(), trusted);
+        assert_eq!(prepared.0, trusted, "relocation must receive verified bytes");
+        assert_ne!(
+            prepared.0,
+            *on_disk.borrow(),
+            "a path swap must be irrelevant"
+        );
+    }
+
+    #[test]
+    fn test_prepared_driver_image_rejects_before_relocation_on_verifier_failure() {
+        let result = prepare_driver_image_with(
+            "/sdcard/drivers/test.drv.elf",
+            |_| Ok(b"untrusted driver bytes".to_vec()),
+            |_, _| ESP_ERR_INVALID_CRC,
+        );
+
+        assert_eq!(
+            result,
+            Err(PrepareDriverImageError::Verify(ESP_ERR_INVALID_CRC))
+        );
+    }
+
+    #[test]
+    fn test_prepared_driver_image_rejects_oversize_before_verification() {
+        let verifier_called = Rc::new(RefCell::new(false));
+        let called = Rc::clone(&verifier_called);
+        let result = prepare_driver_image_with(
+            "/sdcard/drivers/oversized.drv.elf",
+            |_| Ok(vec![0u8; MAX_DRV_SIZE + 1]),
+            move |_, _| {
+                *called.borrow_mut() = true;
+                ESP_OK
+            },
+        );
+
+        assert_eq!(result, Err(PrepareDriverImageError::InvalidSize));
+        assert!(!*verifier_called.borrow());
     }
 }

--- a/components/kernel_rs/src/signing.rs
+++ b/components/kernel_rs/src/signing.rs
@@ -51,6 +51,38 @@ fn sig_path_for(elf_path: &str) -> String {
     format!("{}.sig", elf_path)
 }
 
+fn read_file_bounded(path: &str, max_size: usize) -> Result<Vec<u8>, i32> {
+    let file = fs::File::open(path).map_err(|_| ESP_ERR_NOT_FOUND)?;
+    let mut bytes = Vec::new();
+    file.take((max_size + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|_| ESP_ERR_NOT_FOUND)?;
+    if bytes.len() > max_size {
+        return Err(ESP_ERR_INVALID_SIZE);
+    }
+    Ok(bytes)
+}
+
+/// Verify an already-read file image against the detached signature associated
+/// with `path`. Callers that execute or install the image can keep using the
+/// same byte slice after this returns, avoiding a pathname-based TOCTOU gap.
+pub(crate) fn verify_file_bytes(path: &str, file_bytes: &[u8]) -> i32 {
+    const MAX_VERIFY_SIZE: usize = 16 * 1024 * 1024;
+    if file_bytes.len() > MAX_VERIFY_SIZE {
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    let sig_bytes = match read_file_bounded(&sig_path_for(path), 64) {
+        Ok(bytes) => bytes,
+        Err(err) => return err,
+    };
+    if sig_bytes.len() != 64 {
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    unsafe { signing_verify(file_bytes.as_ptr(), file_bytes.len(), sig_bytes.as_ptr()) }
+}
+
 /// Stream one already-open object through Ed25519 verification and a consumer.
 /// The consumer receives the exact byte slices covered by the signature. This
 /// lets OTA write those slices to an inactive partition without reopening a
@@ -190,31 +222,12 @@ pub unsafe extern "C" fn signing_verify_file(elf_path: *const c_char) -> i32 {
         Err(_) => return ESP_ERR_INVALID_ARG,
     };
 
-    let sig_path = sig_path_for(path_str);
-
-    let sig_bytes = match fs::read(&sig_path) {
-        Ok(b) => b,
-        Err(_) => return ESP_ERR_NOT_FOUND,
+    const MAX_VERIFY_SIZE: usize = 16 * 1024 * 1024;
+    let elf_bytes = match read_file_bounded(path_str, MAX_VERIFY_SIZE) {
+        Ok(bytes) => bytes,
+        Err(err) => return err,
     };
-
-    if sig_bytes.len() != 64 {
-        return ESP_ERR_INVALID_SIZE;
-    }
-
-    // Size limit: reject files > 16 MB to prevent heap exhaustion
-    const MAX_VERIFY_SIZE: u64 = 16 * 1024 * 1024;
-    if let Ok(meta) = fs::metadata(path_str) {
-        if meta.len() > MAX_VERIFY_SIZE {
-            return ESP_ERR_INVALID_SIZE;
-        }
-    }
-
-    let elf_bytes = match fs::read(path_str) {
-        Ok(b) => b,
-        Err(_) => return ESP_ERR_NOT_FOUND,
-    };
-
-    signing_verify(elf_bytes.as_ptr(), elf_bytes.len(), sig_bytes.as_ptr())
+    verify_file_bytes(path_str, &elf_bytes)
 }
 
 /// Return `true` if `<elf_path>.sig` exists on the filesystem.

--- a/docs/security/driver-load-integrity.md
+++ b/docs/security/driver-load-integrity.md
@@ -1,0 +1,17 @@
+# Driver load integrity
+
+Standalone drivers execute native code in kernel context. The loader therefore
+reads each driver ELF exactly once into a size-bounded memory snapshot, verifies
+the detached Ed25519 signature over that snapshot, and relocates bytes from the
+same snapshot. It never reopens the driver pathname between verification and
+relocation.
+
+Replacing the file or its directory entry after the initial read cannot change
+the code passed to the ELF loader. Empty files, files larger than 512 KiB,
+malformed signatures, unavailable signing state, and signature mismatches fail
+before PSRAM allocation or relocation. Debug builds retain the existing
+explicit unsigned-driver development exception; release builds require a valid
+signature.
+
+This change does not alter the on-disk driver or signature format and requires
+no migration.


### PR DESCRIPTION
## Summary

- read each standalone driver ELF exactly once into a bounded memory snapshot
- verify the detached Ed25519 signature over that snapshot
- copy and relocate the same verified bytes instead of reopening the pathname
- cap driver reads at 512 KiB without trusting mutable file metadata
- preserve the debug-only unsigned-driver exception and release fail-closed policy
- document the driver load integrity boundary and confirm no format migration is needed

## Security impact

Previously, the loader verified a driver by pathname and reopened that pathname before relocation. A mutable SD-card entry could therefore be swapped after verification so different native code executed in kernel context. The loader now verifies and relocates one immutable in-memory snapshot, making later path replacement irrelevant.

## Validation

- regression first: the snapshot-binding test failed before implementation and passes afterward
- verifier failure and oversized-image tests prove rejection before relocation
- 1,327 Rust host tests passed serially
- focused driver-loader and signing suites passed after rebasing onto main
- `cargo +esp check` passed for ESP32, ESP32-S2, ESP32-S3, ESP32-C3, and ESP32-C6 (H2 intentionally descoped)
- Recovery release check passed
- full ESP-IDF 5.5 ESP32-S3 firmware compiled and linked; 11% of the smallest app partition remains free
- simulator compiled and all 17 simulator tests passed
- `git diff --check` passed

Closes #72