### PR TITLE
Use canonical architecture slugs in loaders

### DIFF
--- a/components/kernel_rs/src/driver_loader.rs
+++ b/components/kernel_rs/src/driver_loader.rs
@@ -46,7 +46,6 @@ extern "C" {
 
     // Manifest (C/Rust shims)
     fn manifest_parse_file(path: *const c_char, out: *mut CManifest) -> i32;
-    fn manifest_is_compatible(manifest: *const CManifest, current_arch: *const c_char) -> bool;
     fn manifest_path_from_elf(elf_path: *const c_char, out: *mut c_char, out_size: usize);
 
     // Syscall table (C)
@@ -191,13 +190,18 @@ const ESP_LOG_DEBUG: i32 = 4;
 
 static TAG: &[u8] = b"drv_loader\0";
 
-// Current architecture string for manifest compatibility checks
-static CURRENT_ARCH: &[u8] = b"xtensa-esp32s3\0";
-
 // Size of esp_elf_t opaque struct — must be large enough to hold the C struct.
 // We use a byte array as an opaque storage blob.
 // esp_elf_t is typically ~128 bytes; use 256 for safety.
 const ESP_ELF_T_SIZE: usize = 256;
+
+fn manifest_is_compatible_for_arch(manifest: &CManifest, current_arch: &CStr) -> bool {
+    unsafe { crate::ffi::manifest_is_compatible(manifest, current_arch.as_ptr()) }
+}
+
+fn manifest_is_compatible_for_current_arch(manifest: &CManifest) -> bool {
+    manifest_is_compatible_for_arch(manifest, crate::manifest::current_arch_cstr())
+}
 
 // ---------------------------------------------------------------------------
 // State
@@ -487,7 +491,7 @@ pub unsafe extern "C" fn driver_loader_load(path: *const c_char) -> i32 {
             manifest.as_mut_ptr(),
         ) == ESP_OK {
             let manifest = manifest.assume_init();
-            if !manifest_is_compatible(&manifest, CURRENT_ARCH.as_ptr() as *const c_char) {
+            if !manifest_is_compatible_for_current_arch(&manifest) {
                 esp_log_write(
                     ESP_LOG_ERROR,
                     TAG.as_ptr(),
@@ -692,7 +696,7 @@ pub unsafe extern "C" fn driver_loader_load_with_config(
 mod tests {
     use super::*;
     use std::cell::RefCell;
-    use std::ffi::CStr;
+    use std::ffi::{CStr, CString};
     use std::rc::Rc;
 
     fn reset_state() {
@@ -764,6 +768,27 @@ mod tests {
     #[test]
     fn test_max_loaded_drvs_constant() {
         assert_eq!(MAX_LOADED_DRVS, 8, "MAX_LOADED_DRVS must be 8");
+    }
+
+    #[test]
+    fn driver_loader_accepts_matching_canonical_architectures_only() {
+        let universal = CManifest::from(&crate::manifest::Manifest::default());
+        for package_arch in ["esp32", "esp32s2", "esp32s3", "esp32c3", "esp32c6"] {
+            let manifest = CManifest::from(&crate::manifest::Manifest {
+                arch: package_arch.into(),
+                ..Default::default()
+            });
+            let matching = CString::new(package_arch).unwrap();
+            assert!(manifest_is_compatible_for_arch(&universal, &matching));
+            assert!(manifest_is_compatible_for_arch(&manifest, &matching));
+
+            let mismatch = if package_arch == "esp32c3" {
+                CString::new("esp32s3").unwrap()
+            } else {
+                CString::new("esp32c3").unwrap()
+            };
+            assert!(!manifest_is_compatible_for_arch(&manifest, &mismatch));
+        }
     }
 
     #[test]

--- a/components/kernel_rs/src/elf_loader.rs
+++ b/components/kernel_rs/src/elf_loader.rs
@@ -38,9 +38,6 @@ const MALLOC_CAP_SPIRAM: u32 = 1 << 9;
 const PERM_ALL: u32 = 0x7F;
 const PERM_IPC: u32 = 1 << 6;
 
-// Current architecture string for manifest compatibility checks
-static CURRENT_ARCH: &[u8] = b"xtensa-esp32s3\0";
-
 // ---------------------------------------------------------------------------
 // C FFI declarations
 // ---------------------------------------------------------------------------
@@ -78,7 +75,6 @@ extern "C" {
 
     // Manifest (C/Rust)
     fn manifest_parse_file(path: *const c_char, out: *mut CManifest) -> i32;
-    fn manifest_is_compatible(manifest: *const CManifest, current_arch: *const c_char) -> bool;
     fn manifest_path_from_elf(elf_path: *const c_char, out: *mut c_char, out_size: usize);
 
     // Syscall table
@@ -98,6 +94,14 @@ const ESP_LOG_DEBUG: i32 = 4;
 const PD_PASS: i32 = 1;
 
 static TAG: &[u8] = b"elf_loader\0";
+
+fn manifest_is_compatible_for_arch(manifest: &CManifest, current_arch: &CStr) -> bool {
+    unsafe { crate::ffi::manifest_is_compatible(manifest, current_arch.as_ptr()) }
+}
+
+fn manifest_is_compatible_for_current_arch(manifest: &CManifest) -> bool {
+    manifest_is_compatible_for_arch(manifest, crate::manifest::current_arch_cstr())
+}
 
 // Size of esp_elf_t opaque struct storage blob.
 const ESP_ELF_T_SIZE: usize = 256;
@@ -485,7 +489,7 @@ pub unsafe extern "C" fn elf_app_load(
             manifest.as_mut_ptr(),
         ) == ESP_OK {
             let manifest = manifest.assume_init();
-            if !manifest_is_compatible(&manifest, CURRENT_ARCH.as_ptr() as *const c_char) {
+            if !manifest_is_compatible_for_current_arch(&manifest) {
                 esp_log_write(ESP_LOG_ERROR, TAG.as_ptr(), b"App incompatible: %s\0".as_ptr(), path);
                 let _ = permissions_revoke(perm_id, granted_permissions);
                 esp_elf_deinit(elf_ptr);
@@ -1057,6 +1061,7 @@ pub unsafe extern "C" fn elf_app_scan_and_register() -> c_int {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CString;
 
     #[test]
     fn unsigned_manifest_cannot_escalate_beyond_ipc() {
@@ -1076,5 +1081,26 @@ mod tests {
         let app = ElfAppHandle::empty();
         assert_eq!(app.app_id, [0u8; 64]);
         assert_eq!(app.granted_permissions, 0);
+    }
+
+    #[test]
+    fn app_loader_accepts_matching_canonical_architectures_only() {
+        let universal = CManifest::from(&crate::manifest::Manifest::default());
+        for package_arch in ["esp32", "esp32s2", "esp32s3", "esp32c3", "esp32c6"] {
+            let manifest = CManifest::from(&crate::manifest::Manifest {
+                arch: package_arch.into(),
+                ..Default::default()
+            });
+            let matching = CString::new(package_arch).unwrap();
+            assert!(manifest_is_compatible_for_arch(&universal, &matching));
+            assert!(manifest_is_compatible_for_arch(&manifest, &matching));
+
+            let mismatch = if package_arch == "esp32c3" {
+                CString::new("esp32s3").unwrap()
+            } else {
+                CString::new("esp32c3").unwrap()
+            };
+            assert!(!manifest_is_compatible_for_arch(&manifest, &mismatch));
+        }
     }
 }

--- a/components/kernel_rs/src/manifest.rs
+++ b/components/kernel_rs/src/manifest.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Unified manifest parser for apps, drivers, and firmware.
 
+use std::ffi::CStr;
 use std::fs;
 use std::path::Path;
 
@@ -39,6 +40,22 @@ pub fn current_arch() -> &'static str {
     {
         "host" // simulator / unit tests on aarch64 or x86_64
     }
+}
+
+/// Return the canonical runtime architecture slug as a C string for loader ABI
+/// boundaries. This must stay derived from `current_arch()` so package and
+/// catalog slugs cannot drift from the loader value.
+pub fn current_arch_cstr() -> &'static CStr {
+    let bytes: &'static [u8] = match current_arch() {
+        "esp32" => b"esp32\0",
+        "esp32s2" => b"esp32s2\0",
+        "esp32s3" => b"esp32s3\0",
+        "esp32c3" => b"esp32c3\0",
+        "esp32c6" => b"esp32c6\0",
+        "host" => b"host\0",
+        _ => unreachable!("unsupported canonical architecture slug"),
+    };
+    CStr::from_bytes_with_nul(bytes).expect("canonical architecture C string")
 }
 
 /// Manifest entry types.
@@ -839,6 +856,15 @@ mod tests {
         // On the test host this will be "host"; on ESP32-S3 it will be "esp32s3".
         // The important invariant is that it's a non-empty string.
         assert!(!arch.is_empty(), "current_arch() must not be empty");
+    }
+
+    #[test]
+    fn test_current_arch_cstr_matches_canonical_slug() {
+        assert_eq!(
+            current_arch_cstr().to_str().unwrap(),
+            current_arch(),
+            "the loader ABI slug must come from the canonical runtime source"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #45.

## Root cause

Both standalone ELF loaders passed the toolchain label `xtensa-esp32s3` into manifest compatibility checks, while shipped packages and the catalog use canonical chip slugs such as `esp32`, `esp32s3`, and `esp32c3`. Every architecture-qualified package was therefore rejected.

## Change

- derive the loader ABI value from the Rust kernel's existing `manifest::current_arch()` source
- remove the duplicated architecture constants and redundant C-ABI declarations from both loaders
- preserve universal manifests
- exercise matching and mismatching packages across ESP32, S2, S3, C3, and C6
- intentionally exclude H2 because support is descoped

This does not change the manifest format, catalog contract, or on-disk package format.

## Verification

- 1,337 Rust host tests passed
- focused app and driver loader compatibility tests passed
- Rust kernel checks passed for ESP32, S2, S3, C3, and C6
- Recovery release check passed
- full ESP32-S3 firmware build passed; 11% app partition free
- simulator build passed; 17/17 tests passed
- diff whitespace check passed

## Rust migration

The compatibility decision and architecture source stay in Rust. No new C API or bridge is introduced.
