### PR TITLE
Propagate board bus registration failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,16 @@ jobs:
             components/drv_modem_a7682e/src/a7682e_lifecycle.c \
             components/drv_modem_a7682e/src/drv_modem_a7682e.c
 
+      - name: Test board bus initialization failures
+        run: |
+          cc -std=c11 -Wall -Wextra -Werror \
+            -DTHISTLE_BUS_INIT_HOST_TEST \
+            -Icomponents/kernel/tests \
+            components/kernel/src/board_builtin_drivers.c \
+            components/kernel/tests/test_board_bus_init.c \
+            -o /tmp/test_board_bus_init
+          /tmp/test_board_bus_init
+
       - name: Test assistant request bounds under sanitizers
         run: |
           cc -std=c11 -Wall -Wextra -Werror \

--- a/components/kernel/src/board_builtin_drivers.c
+++ b/components/kernel/src/board_builtin_drivers.c
@@ -3,6 +3,9 @@
 // ELF driver files are not present on SPIFFS/SD. Provides bus init helpers
 // and maps driver IDs to compiled-in vtables.
 
+#ifdef THISTLE_BUS_INIT_HOST_TEST
+#include "board_bus_init_test_shim.h"
+#else
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -17,14 +20,18 @@
 #include "drv_epaper_gdeq031t10.h"
 #include "drv_kbd_tca8418.h"
 #include "drv_touch_cst328.h"
+#endif
 
+#ifndef THISTLE_BUS_INIT_HOST_TEST
 static const char *TAG = "board_builtin";
+#endif
 
 // ---------------------------------------------------------------------------
 // Minimal JSON int helper — handles bare integers and quoted hex ("0x34").
 // Searches for "key": <value> and parses the value.
 // ---------------------------------------------------------------------------
 
+#ifndef THISTLE_BUS_INIT_HOST_TEST
 static int json_int(const char *json, const char *key, int default_val)
 {
     if (!json || !key) return default_val;
@@ -43,6 +50,7 @@ static int json_int(const char *json, const char *key, int default_val)
     // Bare integer (possibly negative)
     return (int)strtol(p, NULL, 0);
 }
+#endif
 
 // ---------------------------------------------------------------------------
 // Bus initialisation helpers (called from board_config.rs via FFI)
@@ -68,7 +76,19 @@ esp_err_t board_bus_init_spi(int host, int mosi, int miso, int sclk, int max_tra
     }
     // Store host ID as the "handle" — ELF drivers call hal_bus_get_spi(idx)
     // and cast it back to spi_host_device_t.
-    hal_bus_register_spi(host, (void *)(intptr_t)host);
+    esp_err_t register_ret = hal_bus_register_spi(host, (void *)(intptr_t)host);
+    if (register_ret != ESP_OK) {
+        ESP_LOGE(TAG, "SPI host %d registration failed: %s",
+                 host, esp_err_to_name(register_ret));
+        if (ret == ESP_OK) {
+            esp_err_t cleanup_ret = spi_bus_free((spi_host_device_t)host);
+            if (cleanup_ret != ESP_OK) {
+                ESP_LOGE(TAG, "SPI host %d cleanup failed: %s",
+                         host, esp_err_to_name(cleanup_ret));
+            }
+        }
+        return register_ret;
+    }
     ESP_LOGI(TAG, "SPI host %d ready (MOSI=%d MISO=%d SCLK=%d)", host, mosi, miso, sclk);
     return ESP_OK;
 }
@@ -90,7 +110,17 @@ esp_err_t board_bus_init_i2c(int port, int sda, int scl, int freq_hz)
         ESP_LOGE(TAG, "i2c_new_master_bus port=%d failed: %s", port, esp_err_to_name(ret));
         return ret;
     }
-    hal_bus_register_i2c(port, handle);
+    esp_err_t register_ret = hal_bus_register_i2c(port, handle);
+    if (register_ret != ESP_OK) {
+        ESP_LOGE(TAG, "I2C port %d registration failed: %s",
+                 port, esp_err_to_name(register_ret));
+        esp_err_t cleanup_ret = i2c_del_master_bus(handle);
+        if (cleanup_ret != ESP_OK) {
+            ESP_LOGE(TAG, "I2C port %d cleanup failed: %s",
+                     port, esp_err_to_name(cleanup_ret));
+        }
+        return register_ret;
+    }
     ESP_LOGI(TAG, "I2C port %d ready (SDA=%d SCL=%d)", port, sda, scl);
     return ESP_OK;
 }
@@ -101,6 +131,7 @@ esp_err_t board_bus_init_i2c(int port, int sda, int scl, int freq_hz)
 // sub-object.
 // ---------------------------------------------------------------------------
 
+#ifndef THISTLE_BUS_INIT_HOST_TEST
 esp_err_t board_builtin_driver_init(const char *id, const char *hal_type,
                                     const char *config_json)
 {
@@ -154,12 +185,14 @@ esp_err_t board_builtin_driver_init(const char *id, const char *hal_type,
     ESP_LOGW(TAG, "no builtin for driver id=%s — skipping", id);
     return ESP_OK;
 }
+#endif
 
 // ---------------------------------------------------------------------------
 // GPIO pre-init helper — called from board_config.rs to configure power-enable
 // and other board-level GPIOs before driver initialization.
 // ---------------------------------------------------------------------------
 
+#ifndef THISTLE_BUS_INIT_HOST_TEST
 esp_err_t board_gpio_set_output(int pin, int level, int delay_ms)
 {
     if (pin < 0) return ESP_OK;
@@ -193,3 +226,4 @@ esp_err_t board_gpio_set_output(int pin, int level, int delay_ms)
     }
     return ret;
 }
+#endif

--- a/components/kernel/tests/board_bus_init_test_shim.h
+++ b/components/kernel/tests/board_bus_init_test_shim.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef int esp_err_t;
+typedef int spi_host_device_t;
+typedef int i2c_port_t;
+typedef int gpio_num_t;
+typedef void *i2c_master_bus_handle_t;
+
+typedef struct {
+    int mosi_io_num;
+    int miso_io_num;
+    int sclk_io_num;
+    int quadwp_io_num;
+    int quadhd_io_num;
+    int max_transfer_sz;
+} spi_bus_config_t;
+
+typedef struct {
+    i2c_port_t i2c_port;
+    gpio_num_t sda_io_num;
+    gpio_num_t scl_io_num;
+    int clk_source;
+    int glitch_ignore_cnt;
+    struct {
+        bool enable_internal_pullup;
+    } flags;
+} i2c_master_bus_config_t;
+
+#define ESP_OK 0
+#define ESP_ERR_NO_MEM 0x101
+#define ESP_ERR_INVALID_ARG 0x102
+#define ESP_ERR_INVALID_STATE 0x103
+#define SPI_DMA_CH_AUTO 3
+#define I2C_CLK_SRC_DEFAULT 0
+#define ESP_LOGE(...) ((void)0)
+#define ESP_LOGW(...) ((void)0)
+#define ESP_LOGI(...) ((void)0)
+
+const char *esp_err_to_name(esp_err_t error);
+esp_err_t spi_bus_initialize(spi_host_device_t host, const spi_bus_config_t *config, int dma_channel);
+esp_err_t spi_bus_free(spi_host_device_t host);
+esp_err_t i2c_new_master_bus(const i2c_master_bus_config_t *config,
+                             i2c_master_bus_handle_t *handle);
+esp_err_t i2c_del_master_bus(i2c_master_bus_handle_t handle);
+esp_err_t hal_bus_register_spi(int host_id, void *bus_handle);
+esp_err_t hal_bus_register_i2c(int port, void *bus_handle);

--- a/components/kernel/tests/test_board_bus_init.c
+++ b/components/kernel/tests/test_board_bus_init.c
@@ -1,0 +1,115 @@
+#include <assert.h>
+#include <stdint.h>
+
+#include "board_bus_init_test_shim.h"
+
+esp_err_t board_bus_init_spi(int host, int mosi, int miso, int sclk, int max_transfer_bytes);
+esp_err_t board_bus_init_i2c(int port, int sda, int scl, int freq_hz);
+
+static esp_err_t spi_init_result;
+static esp_err_t spi_register_result;
+static esp_err_t i2c_register_result;
+static esp_err_t spi_free_result;
+static esp_err_t i2c_delete_result;
+static int spi_free_calls;
+static int i2c_delete_calls;
+static int fake_i2c_handle;
+
+const char *esp_err_to_name(esp_err_t error)
+{
+    (void)error;
+    return "test";
+}
+
+esp_err_t spi_bus_initialize(spi_host_device_t host, const spi_bus_config_t *config, int dma_channel)
+{
+    (void)host;
+    (void)config;
+    (void)dma_channel;
+    return spi_init_result;
+}
+
+esp_err_t spi_bus_free(spi_host_device_t host)
+{
+    (void)host;
+    spi_free_calls++;
+    return spi_free_result;
+}
+
+esp_err_t i2c_new_master_bus(const i2c_master_bus_config_t *config,
+                             i2c_master_bus_handle_t *handle)
+{
+    (void)config;
+    *handle = &fake_i2c_handle;
+    return ESP_OK;
+}
+
+esp_err_t i2c_del_master_bus(i2c_master_bus_handle_t handle)
+{
+    assert(handle == &fake_i2c_handle);
+    i2c_delete_calls++;
+    return i2c_delete_result;
+}
+
+esp_err_t hal_bus_register_spi(int host_id, void *bus_handle)
+{
+    (void)host_id;
+    (void)bus_handle;
+    return spi_register_result;
+}
+
+esp_err_t hal_bus_register_i2c(int port, void *bus_handle)
+{
+    (void)port;
+    (void)bus_handle;
+    return i2c_register_result;
+}
+
+static void reset_mocks(void)
+{
+    spi_init_result = ESP_OK;
+    spi_register_result = ESP_OK;
+    i2c_register_result = ESP_OK;
+    spi_free_result = ESP_OK;
+    i2c_delete_result = ESP_OK;
+    spi_free_calls = 0;
+    i2c_delete_calls = 0;
+}
+
+int main(void)
+{
+    reset_mocks();
+    spi_register_result = ESP_ERR_NO_MEM;
+    assert(board_bus_init_spi(2, 1, 2, 3, 4096) == ESP_ERR_NO_MEM);
+    assert(spi_free_calls == 1);
+
+    reset_mocks();
+    spi_register_result = ESP_ERR_NO_MEM;
+    spi_free_result = ESP_ERR_INVALID_STATE;
+    assert(board_bus_init_spi(2, 1, 2, 3, 4096) == ESP_ERR_NO_MEM);
+    assert(spi_free_calls == 1);
+
+    reset_mocks();
+    spi_register_result = ESP_ERR_INVALID_ARG;
+    assert(board_bus_init_spi(0, 1, 2, 3, 4096) == ESP_ERR_INVALID_ARG);
+    assert(spi_free_calls == 1);
+
+    reset_mocks();
+    spi_init_result = ESP_ERR_INVALID_STATE;
+    spi_register_result = ESP_ERR_NO_MEM;
+    assert(board_bus_init_spi(2, 1, 2, 3, 4096) == ESP_ERR_NO_MEM);
+    assert(spi_free_calls == 0);
+
+    reset_mocks();
+    i2c_register_result = ESP_ERR_NO_MEM;
+    assert(board_bus_init_i2c(2, 1, 2, 400000) == ESP_ERR_NO_MEM);
+    assert(i2c_delete_calls == 1);
+
+    reset_mocks();
+    i2c_register_result = ESP_ERR_NO_MEM;
+    i2c_delete_result = ESP_ERR_INVALID_STATE;
+    assert(board_bus_init_i2c(2, 1, 2, 400000) == ESP_ERR_NO_MEM);
+    assert(i2c_delete_calls == 1);
+
+    return 0;
+}

--- a/components/kernel_rs/src/board_config.rs
+++ b/components/kernel_rs/src/board_config.rs
@@ -20,8 +20,6 @@ static BOARD_NAME: Mutex<[u8; 64]> = Mutex::new([0u8; 64]);
 // ESP-IDF FFI for bus init and driver loading
 extern "C" {
     fn hal_set_board_name(name: *const c_char) -> i32;
-    fn hal_bus_register_spi(host_id: i32, handle: *mut std::os::raw::c_void) -> i32;
-    fn hal_bus_register_i2c(port: i32, handle: *mut std::os::raw::c_void) -> i32;
     fn driver_loader_init() -> i32;
     fn driver_loader_load_with_config(path: *const c_char, config: *const c_char) -> i32;
     fn board_init() -> i32;
@@ -46,6 +44,52 @@ fn set_board_name(name: &str) {
         buf[..len].copy_from_slice(&bytes[..len]);
         buf[len] = 0;
     }
+}
+
+fn initialize_configured_buses<S, I>(json: &str, mut init_spi: S, mut init_i2c: I) -> i32
+where
+    S: FnMut(i32, i32, i32, i32, i32) -> i32,
+    I: FnMut(i32, i32, i32, i32) -> i32,
+{
+    let Some(buses_obj) = extract_object(json, "buses") else {
+        return ESP_OK;
+    };
+
+    if let Some(spi_arr) = find_array(&buses_obj, "spi") {
+        for i in 0..4 {
+            let Some(bus) = nth_object(&spi_arr, i) else {
+                break;
+            };
+            let host = json_get_int(&bus, "host").unwrap_or(1) as i32;
+            let mosi = json_get_int(&bus, "mosi").unwrap_or(-1) as i32;
+            let miso = json_get_int(&bus, "miso").unwrap_or(-1) as i32;
+            let sclk = json_get_int(&bus, "sclk").unwrap_or(-1) as i32;
+            let max_bytes =
+                json_get_int(&bus, "max_transfer_bytes").unwrap_or(4096) as i32;
+            let ret = init_spi(host, mosi, miso, sclk, max_bytes);
+            if ret != ESP_OK {
+                return ret;
+            }
+        }
+    }
+
+    if let Some(i2c_arr) = find_array(&buses_obj, "i2c") {
+        for i in 0..4 {
+            let Some(bus) = nth_object(&i2c_arr, i) else {
+                break;
+            };
+            let port = json_get_int(&bus, "port").unwrap_or(0) as i32;
+            let sda = json_get_int(&bus, "sda").unwrap_or(-1) as i32;
+            let scl = json_get_int(&bus, "scl").unwrap_or(-1) as i32;
+            let freq_hz = json_get_int(&bus, "freq_hz").unwrap_or(400000) as i32;
+            let ret = init_i2c(port, sda, scl, freq_hz);
+            if ret != ESP_OK {
+                return ret;
+            }
+        }
+    }
+
+    ESP_OK
 }
 
 // This function does the main work but requires ESP-IDF APIs for bus init.
@@ -140,33 +184,17 @@ fn load_config(config_path: &str) -> i32 {
 
     // Initialize SPI and I2C buses from board.json
     #[cfg(not(test))]
-    if let Some(buses_obj) = extract_object(&json, "buses") {
-        if let Some(spi_arr) = find_array(&buses_obj, "spi") {
-            for i in 0..4 {
-                if let Some(bus) = nth_object(&spi_arr, i) {
-                    let host      = json_get_int(&bus, "host").unwrap_or(1) as i32;
-                    let mosi      = json_get_int(&bus, "mosi").unwrap_or(-1) as i32;
-                    let miso      = json_get_int(&bus, "miso").unwrap_or(-1) as i32;
-                    let sclk      = json_get_int(&bus, "sclk").unwrap_or(-1) as i32;
-                    let max_bytes = json_get_int(&bus, "max_transfer_bytes").unwrap_or(4096) as i32;
-                    unsafe { board_bus_init_spi(host, mosi, miso, sclk, max_bytes); }
-                } else {
-                    break;
-                }
-            }
-        }
-        if let Some(i2c_arr) = find_array(&buses_obj, "i2c") {
-            for i in 0..4 {
-                if let Some(bus) = nth_object(&i2c_arr, i) {
-                    let port    = json_get_int(&bus, "port").unwrap_or(0) as i32;
-                    let sda     = json_get_int(&bus, "sda").unwrap_or(-1) as i32;
-                    let scl     = json_get_int(&bus, "scl").unwrap_or(-1) as i32;
-                    let freq_hz = json_get_int(&bus, "freq_hz").unwrap_or(400000) as i32;
-                    unsafe { board_bus_init_i2c(port, sda, scl, freq_hz); }
-                } else {
-                    break;
-                }
-            }
+    {
+        let ret = initialize_configured_buses(
+            &json,
+            |host, mosi, miso, sclk, max_bytes| unsafe {
+                board_bus_init_spi(host, mosi, miso, sclk, max_bytes)
+            },
+            |port, sda, scl, freq_hz| unsafe { board_bus_init_i2c(port, sda, scl, freq_hz) },
+        );
+        if ret != ESP_OK {
+            // Do not load or start drivers whose configured bus is unavailable.
+            return ret;
         }
     }
 
@@ -441,6 +469,56 @@ pub extern "C" fn board_config_get_wm_name() -> *const c_char {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn bus_failure_stops_initialization_before_dependent_buses() {
+        let json = r#"{
+            "buses": {
+                "spi": [
+                    {"host": 1},
+                    {"host": 2},
+                    {"host": 3}
+                ],
+                "i2c": [{"port": 0}]
+            }
+        }"#;
+        let spi_calls = Cell::new(0);
+        let i2c_calls = Cell::new(0);
+
+        let result = initialize_configured_buses(
+            json,
+            |host, _, _, _, _| {
+                spi_calls.set(spi_calls.get() + 1);
+                if host == 3 { ESP_ERR_NO_MEM } else { ESP_OK }
+            },
+            |_, _, _, _| {
+                i2c_calls.set(i2c_calls.get() + 1);
+                ESP_OK
+            },
+        );
+
+        assert_eq!(result, ESP_ERR_NO_MEM);
+        assert_eq!(spi_calls.get(), 3);
+        assert_eq!(i2c_calls.get(), 0);
+    }
+
+    #[test]
+    fn i2c_initialization_preserves_original_error() {
+        let json = r#"{"buses":{"i2c":[{"port":0},{"port":1}]}}"#;
+        let calls = Cell::new(0);
+        let result = initialize_configured_buses(
+            json,
+            |_, _, _, _, _| ESP_OK,
+            |port, _, _, _| {
+                calls.set(calls.get() + 1);
+                if port == 1 { ESP_ERR_INVALID_ARG } else { ESP_OK }
+            },
+        );
+
+        assert_eq!(result, ESP_ERR_INVALID_ARG);
+        assert_eq!(calls.get(), 2);
+    }
 
     #[test]
     fn test_normalize_tp4065b_power_config_adds_channel_fields_for_esp32s3() {


### PR DESCRIPTION
Closes #54.

## Root cause

The built-in SPI and I2C adapters discarded `hal_bus_register_*` failures and returned success. The Rust board-config path also ignored the adapter result, so boot continued into dependent driver loading and startup with an unavailable bus. A rejected newly-created I2C bus was leaked.

## Change

- return the original HAL registry error from both bus adapters
- free a newly-created SPI bus when registration fails
- leave an already-initialized SPI bus owned by its existing caller
- delete a newly-created I2C bus when registration fails
- preserve the registration error even if cleanup also fails
- make the Rust board orchestrator stop before driver loading/startup on any bus failure
- remove redundant Rust declarations for direct bus registration
- run a host C regression harness in CI for the hardware-adapter boundary

## Verification

- C adapter regression harness passed, including third-bus rejection, null-handle rejection, ownership-aware cleanup, I2C cleanup, and cleanup-error precedence
- 1,339 Rust host tests passed
- Rust kernel checks passed for ESP32, S2, S3, C3, and C6
- Recovery release check passed
- full ESP32-S3 firmware build passed; 11% app partition free
- simulator build passed; 17/17 tests passed
- diff whitespace check passed

ESP32-H2 is intentionally excluded because support is descoped.

## Rust migration

Failure sequencing and the decision to stop dependent driver startup live in Rust. The C change is limited to making the existing ESP-IDF hardware adapter truthful and resource-safe; it does not add a production C API. A future hardware-adapter migration can remove this remaining C boundary without changing the Rust orchestration contract.
