### PR TITLE
Harden SX1262 interrupt lifecycle

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,6 +91,15 @@ jobs:
             -o /tmp/test_board_bus_init
           /tmp/test_board_bus_init
 
+      - name: Test SX1262 interrupt lifecycle
+        run: |
+          c++ -std=c++17 -Wall -Wextra -Werror -pthread \
+            -fsanitize=address,undefined -fno-omit-frame-pointer \
+            -Icomponents/drv_radio_sx1262/tests \
+            components/drv_radio_sx1262/tests/test_sx1262_lifecycle.cpp \
+            -o /tmp/test_sx1262_lifecycle
+          /tmp/test_sx1262_lifecycle
+
       - name: Test assistant request bounds under sanitizers
         run: |
           cc -std=c11 -Wall -Wextra -Werror \

--- a/components/drv_radio_sx1262/src/drv_radio_sx1262.cpp
+++ b/components/drv_radio_sx1262/src/drv_radio_sx1262.cpp
@@ -1,17 +1,37 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // ThistleOS — SX1262 LoRa driver via RadioLib (MIT)
 
+#ifdef SX1262_LIFECYCLE_HOST_TEST
+#include "sx1262_lifecycle_test_shim.hpp"
+#else
 extern "C" {
 #include "drv_radio_sx1262.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "rom/ets_sys.h"
 #include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 #include "freertos/task.h"
 }
+#endif
 
+#ifdef SX1262_LIFECYCLE_HOST_TEST
+#include <atomic>
+#endif
 #include <cstring>
 
+#ifndef SX1262_LIFECYCLE_HOST_TEST
+#define SX1262_TEST_ISR_PAUSE() ((void)0)
+#endif
+
+enum class RadioLifecycle : uint8_t {
+    Stopped,
+    Starting,
+    Running,
+    Stopping,
+};
+
+#ifndef SX1262_LIFECYCLE_HOST_TEST
 /* Arduino constants needed by RadioLibHal base class */
 #define INPUT           0x01
 #define OUTPUT          0x02
@@ -81,6 +101,7 @@ public:
 
     void detachInterrupt(uint32_t interruptNum) override {
         if (interruptNum == RADIOLIB_NC) return;
+        gpio_intr_disable((gpio_num_t)interruptNum);
         gpio_isr_handler_remove((gpio_num_t)interruptNum);
     }
 
@@ -142,6 +163,7 @@ private:
     int _spi_clock;
     spi_device_handle_t _spi;
 };
+#endif
 
 /* ── Driver state ────────────────────────────────────────────────── */
 
@@ -152,20 +174,157 @@ static struct {
     Module *mod;
     hal_radio_rx_cb_t rx_cb;
     void *rx_cb_data;
-    bool initialized;
-    bool receiving;
-    TaskHandle_t irq_task;
-    volatile bool irq_pending;
+#ifdef SX1262_LIFECYCLE_HOST_TEST
+    std::atomic<RadioLifecycle> lifecycle{RadioLifecycle::Stopped};
+    std::atomic<bool> receiving{false};
+    std::atomic<TaskHandle_t> irq_task{nullptr};
+    std::atomic<uint32_t> isr_active{0};
+#else
+    volatile RadioLifecycle lifecycle{RadioLifecycle::Stopped};
+    volatile bool receiving{false};
+    TaskHandle_t irq_task{nullptr};
+    volatile uint32_t isr_active{0};
+    portMUX_TYPE state_lock = portMUX_INITIALIZER_UNLOCKED;
+#endif
+    SemaphoreHandle_t irq_stopped;
 } s_radio;
+
+static RadioLifecycle lifecycle_get(void) {
+#ifdef SX1262_LIFECYCLE_HOST_TEST
+    return s_radio.lifecycle.load(std::memory_order_acquire);
+#else
+    portENTER_CRITICAL(&s_radio.state_lock);
+    RadioLifecycle lifecycle = s_radio.lifecycle;
+    portEXIT_CRITICAL(&s_radio.state_lock);
+    return lifecycle;
+#endif
+}
+
+static void lifecycle_set(RadioLifecycle lifecycle) {
+#ifdef SX1262_LIFECYCLE_HOST_TEST
+    s_radio.lifecycle.store(lifecycle, std::memory_order_release);
+#else
+    portENTER_CRITICAL(&s_radio.state_lock);
+    s_radio.lifecycle = lifecycle;
+    portEXIT_CRITICAL(&s_radio.state_lock);
+#endif
+}
+
+static bool lifecycle_transition(RadioLifecycle from, RadioLifecycle to,
+                                 RadioLifecycle *observed) {
+#ifdef SX1262_LIFECYCLE_HOST_TEST
+    RadioLifecycle expected = from;
+    bool changed = s_radio.lifecycle.compare_exchange_strong(
+        expected, to, std::memory_order_acq_rel, std::memory_order_acquire);
+    if (observed) *observed = expected;
+    return changed;
+#else
+    portENTER_CRITICAL(&s_radio.state_lock);
+    RadioLifecycle current = s_radio.lifecycle;
+    bool changed = current == from;
+    if (changed) s_radio.lifecycle = to;
+    portEXIT_CRITICAL(&s_radio.state_lock);
+    if (observed) *observed = current;
+    return changed;
+#endif
+}
+
+static bool receiving_get(void) {
+#ifdef SX1262_LIFECYCLE_HOST_TEST
+    return s_radio.receiving.load(std::memory_order_acquire);
+#else
+    portENTER_CRITICAL(&s_radio.state_lock);
+    bool receiving = s_radio.receiving;
+    portEXIT_CRITICAL(&s_radio.state_lock);
+    return receiving;
+#endif
+}
+
+static void receiving_set(bool receiving) {
+#ifdef SX1262_LIFECYCLE_HOST_TEST
+    s_radio.receiving.store(receiving, std::memory_order_release);
+#else
+    portENTER_CRITICAL(&s_radio.state_lock);
+    s_radio.receiving = receiving;
+    portEXIT_CRITICAL(&s_radio.state_lock);
+#endif
+}
+
+static TaskHandle_t irq_task_get(void) {
+#ifdef SX1262_LIFECYCLE_HOST_TEST
+    return s_radio.irq_task.load(std::memory_order_acquire);
+#else
+    portENTER_CRITICAL(&s_radio.state_lock);
+    TaskHandle_t task = s_radio.irq_task;
+    portEXIT_CRITICAL(&s_radio.state_lock);
+    return task;
+#endif
+}
+
+static void irq_task_set(TaskHandle_t task) {
+#ifdef SX1262_LIFECYCLE_HOST_TEST
+    s_radio.irq_task.store(task, std::memory_order_release);
+#else
+    portENTER_CRITICAL(&s_radio.state_lock);
+    s_radio.irq_task = task;
+    portEXIT_CRITICAL(&s_radio.state_lock);
+#endif
+}
+
+static uint32_t isr_active_get(void) {
+#ifdef SX1262_LIFECYCLE_HOST_TEST
+    return s_radio.isr_active.load(std::memory_order_acquire);
+#else
+    portENTER_CRITICAL(&s_radio.state_lock);
+    uint32_t active = s_radio.isr_active;
+    portEXIT_CRITICAL(&s_radio.state_lock);
+    return active;
+#endif
+}
+
+static bool radio_is_running(void) {
+    return lifecycle_get() == RadioLifecycle::Running;
+}
+
+static void destroy_radio_objects(void) {
+    delete s_radio.radio; s_radio.radio = nullptr;
+    delete s_radio.mod; s_radio.mod = nullptr;
+    delete s_radio.hal; s_radio.hal = nullptr;
+}
+
+static void reset_runtime_state(void) {
+    s_radio.rx_cb = nullptr;
+    s_radio.rx_cb_data = nullptr;
+    receiving_set(false);
+    irq_task_set(nullptr);
+    lifecycle_set(RadioLifecycle::Stopped);
+}
 
 /* ISR → task notification */
 static void IRAM_ATTR dio1_isr(void) {
-    s_radio.irq_pending = true;
-    BaseType_t wake = pdFALSE;
-    if (s_radio.irq_task) {
-        vTaskNotifyGiveFromISR(s_radio.irq_task, &wake);
+#ifdef SX1262_LIFECYCLE_HOST_TEST
+    s_radio.isr_active.fetch_add(1, std::memory_order_acq_rel);
+    TaskHandle_t task = radio_is_running() ? irq_task_get() : nullptr;
+#else
+    portENTER_CRITICAL_ISR(&s_radio.state_lock);
+    s_radio.isr_active = s_radio.isr_active + 1;
+    TaskHandle_t task = s_radio.lifecycle == RadioLifecycle::Running
+        ? s_radio.irq_task : nullptr;
+    portEXIT_CRITICAL_ISR(&s_radio.state_lock);
+#endif
+    if (task) {
+        SX1262_TEST_ISR_PAUSE();
+        BaseType_t wake = pdFALSE;
+        vTaskNotifyGiveFromISR(task, &wake);
         portYIELD_FROM_ISR(wake);
     }
+#ifdef SX1262_LIFECYCLE_HOST_TEST
+    s_radio.isr_active.fetch_sub(1, std::memory_order_acq_rel);
+#else
+    portENTER_CRITICAL_ISR(&s_radio.state_lock);
+    s_radio.isr_active = s_radio.isr_active - 1;
+    portEXIT_CRITICAL_ISR(&s_radio.state_lock);
+#endif
 }
 
 static void radio_irq_task(void *arg) {
@@ -173,7 +332,7 @@ static void radio_irq_task(void *arg) {
     while (1) {
         ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
 
-        if (!s_radio.initialized || !s_radio.radio) continue;
+        if (!radio_is_running()) break;
 
         /* Read received data */
         uint8_t buf[256];
@@ -188,17 +347,28 @@ static void radio_irq_task(void *arg) {
         }
 
         /* Re-arm RX if in continuous mode */
-        if (s_radio.receiving) {
+        if (radio_is_running() && receiving_get()) {
             s_radio.radio->startReceive();
         }
     }
+
+    xSemaphoreGive(s_radio.irq_stopped);
+#ifdef SX1262_LIFECYCLE_HOST_TEST
+    return;
+#else
+    vTaskSuspend(nullptr);
+#endif
 }
 
 /* ── HAL vtable implementations ──────────────────────────────────── */
 
 static esp_err_t sx1262_init(const void *config) {
-    if (s_radio.initialized) return ESP_OK;
     if (!config) return ESP_ERR_INVALID_ARG;
+
+    RadioLifecycle observed;
+    if (!lifecycle_transition(RadioLifecycle::Stopped, RadioLifecycle::Starting, &observed)) {
+        return observed == RadioLifecycle::Running ? ESP_OK : ESP_ERR_INVALID_STATE;
+    }
 
     memcpy(&s_radio.cfg, config, sizeof(radio_sx1262_config_t));
 
@@ -218,72 +388,108 @@ static esp_err_t sx1262_init(const void *config) {
     int state = s_radio.radio->begin(915.0, 125.0, 7, 5, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, 22);
     if (state != RADIOLIB_ERR_NONE) {
         ESP_LOGE(TAG, "RadioLib begin() failed: %d", state);
-        delete s_radio.radio; s_radio.radio = nullptr;
-        delete s_radio.mod; s_radio.mod = nullptr;
-        delete s_radio.hal; s_radio.hal = nullptr;
+        destroy_radio_objects();
+        reset_runtime_state();
         return ESP_FAIL;
+    }
+
+    s_radio.irq_stopped = xSemaphoreCreateBinary();
+    if (!s_radio.irq_stopped) {
+        s_radio.radio->standby();
+        destroy_radio_objects();
+        reset_runtime_state();
+        return ESP_ERR_NO_MEM;
     }
 
     /* Set DIO1 as interrupt */
     s_radio.radio->setDio1Action(dio1_isr);
 
     /* Create IRQ handler task */
-    xTaskCreate(radio_irq_task, "radio_irq", 4096, nullptr, configMAX_PRIORITIES - 1, &s_radio.irq_task);
+    TaskHandle_t irq_task = nullptr;
+    BaseType_t task_result = xTaskCreate(
+        radio_irq_task,
+        "radio_irq",
+        4096,
+        nullptr,
+        configMAX_PRIORITIES - 1,
+        &irq_task);
+    if (task_result != pdPASS || !irq_task) {
+        s_radio.radio->clearDio1Action();
+        s_radio.radio->standby();
+        vSemaphoreDelete(s_radio.irq_stopped);
+        s_radio.irq_stopped = nullptr;
+        destroy_radio_objects();
+        reset_runtime_state();
+        return ESP_ERR_NO_MEM;
+    }
 
-    s_radio.initialized = true;
+    irq_task_set(irq_task);
+    lifecycle_set(RadioLifecycle::Running);
     ESP_LOGI(TAG, "SX1262 initialized via RadioLib");
     return ESP_OK;
 }
 
 static void sx1262_deinit(void) {
-    if (!s_radio.initialized) return;
+    if (!lifecycle_transition(RadioLifecycle::Running, RadioLifecycle::Stopping, nullptr)) {
+        return;
+    }
 
-    if (s_radio.irq_task) {
-        vTaskDelete(s_radio.irq_task);
-        s_radio.irq_task = nullptr;
+    receiving_set(false);
+    s_radio.radio->clearDio1Action();
+
+    while (isr_active_get() != 0) {
+        vTaskDelay(1);
+    }
+
+    TaskHandle_t irq_task = irq_task_get();
+    if (irq_task) {
+        xTaskNotifyGive(irq_task);
+        xSemaphoreTake(s_radio.irq_stopped, portMAX_DELAY);
+        vTaskDelete(irq_task);
+        irq_task_set(nullptr);
     }
 
     s_radio.radio->standby();
 
-    delete s_radio.radio; s_radio.radio = nullptr;
-    delete s_radio.mod; s_radio.mod = nullptr;
-    delete s_radio.hal; s_radio.hal = nullptr;
+    vSemaphoreDelete(s_radio.irq_stopped);
+    s_radio.irq_stopped = nullptr;
+    destroy_radio_objects();
 
-    s_radio.initialized = false;
+    reset_runtime_state();
     ESP_LOGI(TAG, "SX1262 deinitialized");
 }
 
 static esp_err_t sx1262_set_frequency(uint32_t freq_hz) {
-    if (!s_radio.initialized) return ESP_ERR_INVALID_STATE;
+    if (!radio_is_running()) return ESP_ERR_INVALID_STATE;
     float mhz = freq_hz / 1000000.0f;
     int state = s_radio.radio->setFrequency(mhz);
     return state == RADIOLIB_ERR_NONE ? ESP_OK : ESP_FAIL;
 }
 
 static esp_err_t sx1262_set_tx_power(int8_t dbm) {
-    if (!s_radio.initialized) return ESP_ERR_INVALID_STATE;
+    if (!radio_is_running()) return ESP_ERR_INVALID_STATE;
     int state = s_radio.radio->setOutputPower(dbm);
     return state == RADIOLIB_ERR_NONE ? ESP_OK : ESP_FAIL;
 }
 
 static esp_err_t sx1262_set_bandwidth(uint32_t bw_hz) {
-    if (!s_radio.initialized) return ESP_ERR_INVALID_STATE;
+    if (!radio_is_running()) return ESP_ERR_INVALID_STATE;
     float bw_khz = bw_hz / 1000.0f;
     int state = s_radio.radio->setBandwidth(bw_khz);
     return state == RADIOLIB_ERR_NONE ? ESP_OK : ESP_FAIL;
 }
 
 static esp_err_t sx1262_set_spreading_factor(uint8_t sf) {
-    if (!s_radio.initialized) return ESP_ERR_INVALID_STATE;
+    if (!radio_is_running()) return ESP_ERR_INVALID_STATE;
     int state = s_radio.radio->setSpreadingFactor(sf);
     return state == RADIOLIB_ERR_NONE ? ESP_OK : ESP_FAIL;
 }
 
 static esp_err_t sx1262_send(const uint8_t *data, size_t len) {
-    if (!s_radio.initialized) return ESP_ERR_INVALID_STATE;
+    if (!radio_is_running()) return ESP_ERR_INVALID_STATE;
     if (!data || len == 0 || len > 255) return ESP_ERR_INVALID_ARG;
 
-    s_radio.receiving = false;
+    receiving_set(false);
     int state = s_radio.radio->transmit((uint8_t *)data, len);
 
     if (state == RADIOLIB_ERR_NONE) {
@@ -295,11 +501,11 @@ static esp_err_t sx1262_send(const uint8_t *data, size_t len) {
 }
 
 static esp_err_t sx1262_start_receive(hal_radio_rx_cb_t cb, void *user_data) {
-    if (!s_radio.initialized) return ESP_ERR_INVALID_STATE;
+    if (!radio_is_running()) return ESP_ERR_INVALID_STATE;
 
     s_radio.rx_cb = cb;
     s_radio.rx_cb_data = user_data;
-    s_radio.receiving = true;
+    receiving_set(true);
 
     int state = s_radio.radio->startReceive();
     if (state != RADIOLIB_ERR_NONE) {
@@ -312,19 +518,19 @@ static esp_err_t sx1262_start_receive(hal_radio_rx_cb_t cb, void *user_data) {
 }
 
 static esp_err_t sx1262_stop_receive(void) {
-    if (!s_radio.initialized) return ESP_ERR_INVALID_STATE;
-    s_radio.receiving = false;
+    if (!radio_is_running()) return ESP_ERR_INVALID_STATE;
+    receiving_set(false);
     s_radio.radio->standby();
     return ESP_OK;
 }
 
 static int sx1262_get_rssi(void) {
-    if (!s_radio.initialized) return -128;
+    if (!radio_is_running()) return -128;
     return (int)s_radio.radio->getRSSI();
 }
 
 static esp_err_t sx1262_sleep(bool enter) {
-    if (!s_radio.initialized) return ESP_ERR_INVALID_STATE;
+    if (!radio_is_running()) return ESP_ERR_INVALID_STATE;
     if (enter) {
         s_radio.radio->sleep();
     } else {

--- a/components/drv_radio_sx1262/tests/sx1262_lifecycle_test_shim.hpp
+++ b/components/drv_radio_sx1262/tests/sx1262_lifecycle_test_shim.hpp
@@ -1,0 +1,289 @@
+#pragma once
+
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+using esp_err_t = int;
+using spi_host_device_t = int;
+using gpio_num_t = int;
+using BaseType_t = int;
+using UBaseType_t = unsigned int;
+using TickType_t = unsigned int;
+using hal_radio_rx_cb_t = void (*)(const uint8_t *, size_t, int, void *);
+
+constexpr esp_err_t ESP_OK = 0;
+constexpr esp_err_t ESP_FAIL = -1;
+constexpr esp_err_t ESP_ERR_NO_MEM = 0x101;
+constexpr esp_err_t ESP_ERR_INVALID_ARG = 0x102;
+constexpr esp_err_t ESP_ERR_INVALID_STATE = 0x103;
+constexpr BaseType_t pdFALSE = 0;
+constexpr BaseType_t pdTRUE = 1;
+constexpr BaseType_t pdPASS = 1;
+constexpr TickType_t portMAX_DELAY = UINT32_MAX;
+constexpr UBaseType_t configMAX_PRIORITIES = 25;
+constexpr int RADIOLIB_ERR_NONE = 0;
+constexpr int RADIOLIB_SX126X_SYNC_WORD_PRIVATE = 0x12;
+
+#define IRAM_ATTR
+#define ESP_LOGD(...) ((void)0)
+#define ESP_LOGE(...) ((void)0)
+#define ESP_LOGI(...) ((void)0)
+#define portYIELD_FROM_ISR(...) ((void)0)
+
+struct radio_sx1262_config_t {
+    spi_host_device_t spi_host;
+    gpio_num_t pin_cs;
+    gpio_num_t pin_reset;
+    gpio_num_t pin_busy;
+    gpio_num_t pin_dio1;
+    int spi_clock_hz;
+};
+
+struct hal_radio_driver_t {
+    esp_err_t (*init)(const void *);
+    void (*deinit)(void);
+    esp_err_t (*set_frequency)(uint32_t);
+    esp_err_t (*set_tx_power)(int8_t);
+    esp_err_t (*set_bandwidth)(uint32_t);
+    esp_err_t (*set_spreading_factor)(uint8_t);
+    esp_err_t (*send)(const uint8_t *, size_t);
+    esp_err_t (*start_receive)(hal_radio_rx_cb_t, void *);
+    esp_err_t (*stop_receive)(void);
+    int (*get_rssi)(void);
+    esp_err_t (*sleep)(bool);
+    const char *name;
+};
+
+namespace sx1262_test {
+
+enum class Event {
+    Attach,
+    Detach,
+    TaskCreate,
+    TaskExit,
+    Standby,
+    RadioDelete,
+    ModuleDelete,
+    HalDelete,
+    SemaphoreDelete,
+};
+
+inline std::mutex events_mutex;
+inline std::vector<Event> events;
+inline bool fail_task_create;
+inline bool fail_semaphore_create;
+inline bool interrupt_attached;
+inline int begin_result = RADIOLIB_ERR_NONE;
+inline int read_calls;
+inline int rearm_calls;
+inline std::mutex read_mutex;
+inline std::condition_variable read_cv;
+inline bool block_read;
+inline bool read_entered;
+inline bool release_read;
+inline std::mutex isr_mutex;
+inline std::condition_variable isr_cv;
+inline bool block_isr;
+inline bool isr_entered;
+inline bool release_isr;
+
+inline void record(Event event)
+{
+    std::lock_guard<std::mutex> lock(events_mutex);
+    events.push_back(event);
+}
+
+inline void reset()
+{
+    std::lock_guard<std::mutex> lock(events_mutex);
+    events.clear();
+    fail_task_create = false;
+    fail_semaphore_create = false;
+    interrupt_attached = false;
+    begin_result = RADIOLIB_ERR_NONE;
+    read_calls = 0;
+    rearm_calls = 0;
+    block_read = false;
+    read_entered = false;
+    release_read = false;
+    block_isr = false;
+    isr_entered = false;
+    release_isr = false;
+}
+
+struct TestTask {
+    std::mutex mutex;
+    std::condition_variable cv;
+    unsigned notifications = 0;
+    std::thread thread;
+};
+
+struct TestSemaphore {
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool available = false;
+};
+
+inline thread_local TestTask *current_task;
+
+} // namespace sx1262_test
+
+using TaskHandle_t = sx1262_test::TestTask *;
+using SemaphoreHandle_t = sx1262_test::TestSemaphore *;
+
+inline BaseType_t xTaskCreate(void (*entry)(void *), const char *, uint32_t, void *arg,
+                              UBaseType_t, TaskHandle_t *out)
+{
+    sx1262_test::record(sx1262_test::Event::TaskCreate);
+    if (sx1262_test::fail_task_create) {
+        *out = nullptr;
+        return pdFALSE;
+    }
+    auto *task = new sx1262_test::TestTask;
+    *out = task;
+    task->thread = std::thread([task, entry, arg] {
+        sx1262_test::current_task = task;
+        entry(arg);
+        sx1262_test::record(sx1262_test::Event::TaskExit);
+    });
+    return pdPASS;
+}
+
+inline uint32_t ulTaskNotifyTake(BaseType_t, TickType_t)
+{
+    auto *task = sx1262_test::current_task;
+    std::unique_lock<std::mutex> lock(task->mutex);
+    task->cv.wait(lock, [task] { return task->notifications > 0; });
+    task->notifications--;
+    return 1;
+}
+
+inline BaseType_t xTaskNotifyGive(TaskHandle_t task)
+{
+    if (!task) return pdFALSE;
+    {
+        std::lock_guard<std::mutex> lock(task->mutex);
+        task->notifications++;
+    }
+    task->cv.notify_one();
+    return pdTRUE;
+}
+
+inline void vTaskNotifyGiveFromISR(TaskHandle_t task, BaseType_t *wake)
+{
+    *wake = xTaskNotifyGive(task);
+}
+
+inline void vTaskDelete(TaskHandle_t task)
+{
+    if (!task) return;
+    xTaskNotifyGive(task);
+    if (task->thread.joinable()) task->thread.join();
+    delete task;
+}
+
+inline void pause_isr()
+{
+    std::unique_lock<std::mutex> lock(sx1262_test::isr_mutex);
+    sx1262_test::isr_entered = true;
+    sx1262_test::isr_cv.notify_all();
+    if (sx1262_test::block_isr) {
+        sx1262_test::isr_cv.wait(lock, [] { return sx1262_test::release_isr; });
+    }
+}
+
+#define SX1262_TEST_ISR_PAUSE() pause_isr()
+
+inline void vTaskDelay(TickType_t)
+{
+    std::this_thread::yield();
+}
+
+inline SemaphoreHandle_t xSemaphoreCreateBinary()
+{
+    if (sx1262_test::fail_semaphore_create) return nullptr;
+    return new sx1262_test::TestSemaphore;
+}
+
+inline BaseType_t xSemaphoreGive(SemaphoreHandle_t semaphore)
+{
+    {
+        std::lock_guard<std::mutex> lock(semaphore->mutex);
+        semaphore->available = true;
+    }
+    semaphore->cv.notify_one();
+    return pdTRUE;
+}
+
+inline BaseType_t xSemaphoreTake(SemaphoreHandle_t semaphore, TickType_t)
+{
+    std::unique_lock<std::mutex> lock(semaphore->mutex);
+    semaphore->cv.wait(lock, [semaphore] { return semaphore->available; });
+    semaphore->available = false;
+    return pdTRUE;
+}
+
+inline void vSemaphoreDelete(SemaphoreHandle_t semaphore)
+{
+    sx1262_test::record(sx1262_test::Event::SemaphoreDelete);
+    delete semaphore;
+}
+
+class ThistleHal {
+public:
+    ThistleHal(spi_host_device_t, int) {}
+    ~ThistleHal() { sx1262_test::record(sx1262_test::Event::HalDelete); }
+};
+
+class Module {
+public:
+    Module(ThistleHal *, int, int, int, int) {}
+    ~Module() { sx1262_test::record(sx1262_test::Event::ModuleDelete); }
+};
+
+class SX1262 {
+public:
+    explicit SX1262(Module *) {}
+    ~SX1262() { sx1262_test::record(sx1262_test::Event::RadioDelete); }
+
+    int begin(float, float, int, int, int, int) { return sx1262_test::begin_result; }
+    void setDio1Action(void (*)(void)) {
+        sx1262_test::interrupt_attached = true;
+        sx1262_test::record(sx1262_test::Event::Attach);
+    }
+    void clearDio1Action() {
+        sx1262_test::interrupt_attached = false;
+        sx1262_test::record(sx1262_test::Event::Detach);
+    }
+    size_t getPacketLength() { return 1; }
+    int readData(uint8_t *data, size_t) {
+        data[0] = 0x42;
+        std::unique_lock<std::mutex> lock(sx1262_test::read_mutex);
+        sx1262_test::read_calls++;
+        sx1262_test::read_entered = true;
+        sx1262_test::read_cv.notify_all();
+        if (sx1262_test::block_read) {
+            sx1262_test::read_cv.wait(lock, [] { return sx1262_test::release_read; });
+        }
+        return RADIOLIB_ERR_NONE;
+    }
+    float getRSSI() { return -42.0f; }
+    int startReceive() {
+        sx1262_test::rearm_calls++;
+        return RADIOLIB_ERR_NONE;
+    }
+    int standby() {
+        sx1262_test::record(sx1262_test::Event::Standby);
+        return RADIOLIB_ERR_NONE;
+    }
+    int setFrequency(float) { return RADIOLIB_ERR_NONE; }
+    int setOutputPower(int8_t) { return RADIOLIB_ERR_NONE; }
+    int setBandwidth(float) { return RADIOLIB_ERR_NONE; }
+    int setSpreadingFactor(uint8_t) { return RADIOLIB_ERR_NONE; }
+    int transmit(uint8_t *, size_t) { return RADIOLIB_ERR_NONE; }
+    int sleep() { return RADIOLIB_ERR_NONE; }
+};

--- a/components/drv_radio_sx1262/tests/test_sx1262_lifecycle.cpp
+++ b/components/drv_radio_sx1262/tests/test_sx1262_lifecycle.cpp
@@ -1,0 +1,118 @@
+#include <algorithm>
+#include <cassert>
+
+#define SX1262_LIFECYCLE_HOST_TEST
+#include "../src/drv_radio_sx1262.cpp"
+
+static size_t event_index(sx1262_test::Event event)
+{
+    const auto it = std::find(sx1262_test::events.begin(), sx1262_test::events.end(), event);
+    assert(it != sx1262_test::events.end());
+    return static_cast<size_t>(it - sx1262_test::events.begin());
+}
+
+static size_t event_count(sx1262_test::Event event)
+{
+    return static_cast<size_t>(std::count(
+        sx1262_test::events.begin(), sx1262_test::events.end(), event));
+}
+
+static bool has_event(sx1262_test::Event event)
+{
+    std::lock_guard<std::mutex> lock(sx1262_test::events_mutex);
+    return std::find(sx1262_test::events.begin(), sx1262_test::events.end(), event)
+        != sx1262_test::events.end();
+}
+
+static radio_sx1262_config_t config()
+{
+    return {1, 2, 3, 4, 5, 8000000};
+}
+
+int main()
+{
+    auto cfg = config();
+
+    sx1262_test::reset();
+    sx1262_test::fail_task_create = true;
+    assert(sx1262_init(&cfg) == ESP_ERR_NO_MEM);
+    assert(!sx1262_test::interrupt_attached);
+    assert(event_index(sx1262_test::Event::Detach) < event_index(sx1262_test::Event::RadioDelete));
+    assert(event_index(sx1262_test::Event::RadioDelete) < event_index(sx1262_test::Event::ModuleDelete));
+    assert(event_index(sx1262_test::Event::ModuleDelete) < event_index(sx1262_test::Event::HalDelete));
+    assert(event_count(sx1262_test::Event::SemaphoreDelete) == 1);
+
+    sx1262_test::fail_task_create = false;
+    assert(sx1262_init(&cfg) == ESP_OK);
+    sx1262_deinit();
+
+    sx1262_test::reset();
+    sx1262_test::fail_semaphore_create = true;
+    assert(sx1262_init(&cfg) == ESP_ERR_NO_MEM);
+    assert(!sx1262_test::interrupt_attached);
+    assert(event_count(sx1262_test::Event::Attach) == 0);
+    assert(event_count(sx1262_test::Event::RadioDelete) == 1);
+
+    sx1262_test::fail_semaphore_create = false;
+    assert(sx1262_init(&cfg) == ESP_OK);
+    sx1262_deinit();
+
+    sx1262_test::reset();
+    assert(sx1262_init(&cfg) == ESP_OK);
+    assert(sx1262_start_receive(nullptr, nullptr) == ESP_OK);
+    sx1262_test::block_read = true;
+    dio1_isr();
+
+    {
+        std::unique_lock<std::mutex> lock(sx1262_test::read_mutex);
+        sx1262_test::read_cv.wait(lock, [] { return sx1262_test::read_entered; });
+    }
+
+    std::thread deinit_thread([] { sx1262_deinit(); });
+    while (!has_event(sx1262_test::Event::Detach)) std::this_thread::yield();
+    assert(!has_event(sx1262_test::Event::RadioDelete));
+    {
+        std::lock_guard<std::mutex> lock(sx1262_test::read_mutex);
+        sx1262_test::release_read = true;
+    }
+    sx1262_test::read_cv.notify_all();
+    deinit_thread.join();
+    sx1262_deinit();
+
+    assert(!sx1262_test::interrupt_attached);
+    assert(event_index(sx1262_test::Event::Detach) < event_index(sx1262_test::Event::TaskExit));
+    assert(event_index(sx1262_test::Event::TaskExit) < event_index(sx1262_test::Event::Standby));
+    assert(event_index(sx1262_test::Event::Standby) < event_index(sx1262_test::Event::RadioDelete));
+    assert(sx1262_test::rearm_calls == 1);
+
+    sx1262_test::reset();
+    assert(sx1262_init(&cfg) == ESP_OK);
+    sx1262_test::block_isr = true;
+    std::thread isr_thread([] { dio1_isr(); });
+    {
+        std::unique_lock<std::mutex> lock(sx1262_test::isr_mutex);
+        sx1262_test::isr_cv.wait(lock, [] { return sx1262_test::isr_entered; });
+    }
+    std::thread isr_deinit_thread([] { sx1262_deinit(); });
+    while (!has_event(sx1262_test::Event::Detach)) std::this_thread::yield();
+    assert(!has_event(sx1262_test::Event::RadioDelete));
+    {
+        std::lock_guard<std::mutex> lock(sx1262_test::isr_mutex);
+        sx1262_test::release_isr = true;
+    }
+    sx1262_test::isr_cv.notify_all();
+    isr_thread.join();
+    isr_deinit_thread.join();
+    assert(event_index(sx1262_test::Event::Detach) < event_index(sx1262_test::Event::TaskExit));
+    assert(event_index(sx1262_test::Event::TaskExit) < event_index(sx1262_test::Event::RadioDelete));
+
+    for (int i = 0; i < 100; ++i) {
+        sx1262_test::reset();
+        assert(sx1262_init(&cfg) == ESP_OK);
+        dio1_isr();
+        sx1262_deinit();
+        sx1262_deinit();
+        assert(!sx1262_test::interrupt_attached);
+    }
+    return 0;
+}


### PR DESCRIPTION
Closes #51
Closes #52

## Root cause

The SX1262 adapter attached DIO1 before creating its worker but ignored task-creation failure, so initialization could report success with no interrupt consumer. Deinitialization then deleted the worker and RadioLib objects without first detaching DIO1 or waiting for an interrupt/worker already in flight.

## Lifecycle invariant

- no ISR publishes work after stopping begins
- an in-flight ISR drains before task destruction
- DIO1 is detached before the worker or RadioLib objects are destroyed
- the worker acknowledges exit before deinit deletes it
- every failed initialization fully unwinds and a clean retry remains possible
- repeated deinit is harmless

## Changes

- add explicit stopped/starting/running/stopping lifecycle state
- protect production ISR-visible state with ESP-IDF critical sections
- detach DIO1 and drain an in-flight ISR before stopping the worker
- add a worker-exit semaphore handshake before task/object destruction
- return `ESP_ERR_NO_MEM` and fully unwind failed semaphore/task creation
- add an actual-source host harness covering failure cleanup and teardown races
- run that harness under AddressSanitizer and UndefinedBehaviorSanitizer in CI

This does not add a new production C API. It hardens the existing temporary RadioLib C++ adapter and makes its lifecycle contract executable for a later Rust replacement.

## Verification

- regression-first: the new actual-source harness failed against the vulnerable implementation because task-creation failure incorrectly returned success
- post-fix host harness passes under ASAN and UBSAN, including blocked worker and in-flight ISR teardown races plus 100 repeated init/interrupt/deinit cycles
- full Rust host suite: 1,339 passed, 0 failed
- full ESP32-S3 firmware build passes; application image has 0x44010 bytes (11%) free
- H2 is intentionally excluded from scope
