### PR TITLE
Fix e-paper packed row stride

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,6 +100,13 @@ jobs:
             -o /tmp/test_sx1262_lifecycle
           /tmp/test_sx1262_lifecycle
 
+      - name: Test e-paper packed-row blitting
+        run: |
+          cc -std=c11 -Wall -Wextra -Werror \
+            components/drv_epaper_gdeq031t10/tests/test_packed_blit.c \
+            -o /tmp/test_epaper_packed_blit
+          /tmp/test_epaper_packed_blit
+
       - name: Test assistant request bounds under sanitizers
         run: |
           cc -std=c11 -Wall -Wextra -Werror \

--- a/components/drv_epaper_gdeq031t10/src/drv_epaper_gdeq031t10.c
+++ b/components/drv_epaper_gdeq031t10/src/drv_epaper_gdeq031t10.c
@@ -16,6 +16,7 @@
 #include "freertos/task.h"
 #include "driver/spi_master.h"
 #include "driver/gpio.h"
+#include "packed_blit.h"
 
 #include <string.h>
 #include <stdlib.h>
@@ -300,17 +301,7 @@ static esp_err_t gdeq031t10_flush(const hal_area_t *area, const uint8_t *color_d
     }
 
     /* Slow path: arbitrary rectangle, bit-by-bit. */
-    uint16_t src_w = x2 - x1 + 1;
-    for (uint16_t row = y1; row <= y2; row++) {
-        for (uint16_t col = x1; col <= x2; col++) {
-            uint32_t src_bit_idx = (uint32_t)(row - y1) * src_w + (col - x1);
-            uint8_t  src_bit     = (color_data[src_bit_idx >> 3] >> (7 - (src_bit_idx & 7))) & 1;
-            uint32_t dst_bit_idx = (uint32_t)row * EPD_WIDTH + col;
-            uint8_t  dst_mask    = 0x80u >> (dst_bit_idx & 7);
-            if (src_bit) s_epd.fb[dst_bit_idx >> 3] |=  dst_mask;
-            else         s_epd.fb[dst_bit_idx >> 3] &= ~dst_mask;
-        }
-    }
+    epaper_blit_packed_rect(s_epd.fb, EPD_WIDTH, x1, y1, x2, y2, color_data);
     return ESP_OK;
 }
 

--- a/components/drv_epaper_gdeq031t10/src/packed_blit.h
+++ b/components/drv_epaper_gdeq031t10/src/packed_blit.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Internal helper kept separate so the legacy C implementation's packed-row
+ * contract can be exercised on the host. Source rows are byte-padded. */
+static inline void epaper_blit_packed_rect(
+    uint8_t *framebuffer,
+    size_t framebuffer_width,
+    uint16_t x1,
+    uint16_t y1,
+    uint16_t x2,
+    uint16_t y2,
+    const uint8_t *color_data)
+{
+    size_t src_width = (size_t)x2 - x1 + 1;
+    size_t src_row_bytes = (src_width + 7) / 8;
+
+    for (uint16_t row = y1; row <= y2; row++) {
+        const uint8_t *src_row = color_data + (size_t)(row - y1) * src_row_bytes;
+        for (uint16_t col = x1; col <= x2; col++) {
+            size_t src_bit = (size_t)col - x1;
+            uint8_t value = (src_row[src_bit >> 3] >> (7 - (src_bit & 7))) & 1;
+            size_t dst_bit = (size_t)row * framebuffer_width + col;
+            uint8_t mask = 0x80u >> (dst_bit & 7);
+
+            if (value) framebuffer[dst_bit >> 3] |= mask;
+            else       framebuffer[dst_bit >> 3] &= (uint8_t)~mask;
+        }
+    }
+}

--- a/components/drv_epaper_gdeq031t10/tests/test_packed_blit.c
+++ b/components/drv_epaper_gdeq031t10/tests/test_packed_blit.c
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "../src/packed_blit.h"
+
+#define WIDTH 240
+#define HEIGHT 10
+#define ROW_BYTES (WIDTH / 8)
+
+int main(void)
+{
+    uint8_t framebuffer[ROW_BYTES * HEIGHT] = {0};
+
+    const uint8_t three_by_two[] = {0xA0, 0x40};
+    epaper_blit_packed_rect(framebuffer, WIDTH, 1, 2, 3, 3, three_by_two);
+    assert(framebuffer[2 * ROW_BYTES] == 0x50);
+    assert(framebuffer[3 * ROW_BYTES] == 0x20);
+
+    memset(framebuffer, 0, sizeof(framebuffer));
+    const uint8_t nine_by_two[] = {0xAA, 0x80, 0x55, 0x00};
+    epaper_blit_packed_rect(framebuffer, WIDTH, 8, 4, 16, 5, nine_by_two);
+    assert(framebuffer[4 * ROW_BYTES + 1] == 0xAA);
+    assert(framebuffer[4 * ROW_BYTES + 2] == 0x80);
+    assert(framebuffer[5 * ROW_BYTES + 1] == 0x55);
+    assert(framebuffer[5 * ROW_BYTES + 2] == 0x00);
+
+    memset(framebuffer, 0, sizeof(framebuffer));
+    uint8_t full_width[ROW_BYTES * 2];
+    memset(full_width, 0xA5, ROW_BYTES);
+    memset(full_width + ROW_BYTES, 0x5A, ROW_BYTES);
+    epaper_blit_packed_rect(framebuffer, WIDTH, 0, 7, WIDTH - 1, 8, full_width);
+    assert(memcmp(framebuffer + 7 * ROW_BYTES, full_width, sizeof(full_width)) == 0);
+
+    return 0;
+}

--- a/components/kernel_rs/src/drv_epaper_gdeq031t10.rs
+++ b/components/kernel_rs/src/drv_epaper_gdeq031t10.rs
@@ -662,7 +662,8 @@ pub unsafe extern "C" fn gdeq031t10_deinit() {
 /// Flush — copy pixel data from `color_data` into the in-memory framebuffer.
 ///
 /// `area` defines the rectangular region being updated. Data format is
-/// 1-bit packed (MSB first), matching the native panel and LVGL 1bpp mode.
+/// 1-bit packed (MSB first), with each source row padded to `(width + 7) / 8`
+/// bytes, matching the native panel and LVGL 1bpp mode.
 /// The actual SPI transfer to the panel is deferred to `refresh()`.
 pub unsafe extern "C" fn gdeq031t10_flush(area: *const HalArea, color_data: *const u8) -> i32 {
     let s = state();
@@ -691,12 +692,13 @@ pub unsafe extern "C" fn gdeq031t10_flush(area: *const HalArea, color_data: *con
     // Updates only the in-memory framebuffer (fast). The actual panel refresh
     // is triggered separately via refresh().
     let src_w = x2 - x1 + 1;
+    let src_row_bytes = (src_w + 7) / 8;
     let fb = std::slice::from_raw_parts_mut(fb_ptr(), EPD_FB_BYTES);
 
     for row in y1..=y2 {
         for col in x1..=x2 {
-            let src_bit_idx = (row - y1) * src_w + (col - x1);
-            let src_byte = *color_data.add(src_bit_idx / 8);
+            let src_bit_idx = col - x1;
+            let src_byte = *color_data.add((row - y1) * src_row_bytes + src_bit_idx / 8);
             let src_bit = (src_byte >> (7 - (src_bit_idx & 7))) & 1;
 
             let dst_bit_idx = row * EPD_WIDTH + col;
@@ -1274,6 +1276,55 @@ mod tests {
         assert_eq!(unsafe { *fb_ptr() } & 0x80, 0x80, "pixel (0,0) should be white");
 
         unsafe { gdeq031t10_deinit() };
+    }
+
+    #[test]
+    fn test_flush_uses_padded_rows_for_three_by_two_rectangle() {
+        reset_state();
+        state_mut().initialized = true;
+
+        let area = HalArea { x1: 1, y1: 2, x2: 3, y2: 3 };
+        let data = [0b1010_0000, 0b0100_0000];
+        assert_eq!(unsafe { gdeq031t10_flush(&area, data.as_ptr()) }, ESP_OK);
+
+        let fb = unsafe { std::slice::from_raw_parts(fb_ptr(), EPD_FB_BYTES) };
+        let row_bytes = EPD_WIDTH / 8;
+        assert_eq!(fb[2 * row_bytes], 0b0101_0000);
+        assert_eq!(fb[3 * row_bytes], 0b0010_0000);
+    }
+
+    #[test]
+    fn test_flush_uses_padded_rows_for_nine_by_two_rectangle() {
+        reset_state();
+        state_mut().initialized = true;
+
+        let area = HalArea { x1: 8, y1: 4, x2: 16, y2: 5 };
+        let data = [0b1010_1010, 0b1000_0000, 0b0101_0101, 0b0000_0000];
+        assert_eq!(unsafe { gdeq031t10_flush(&area, data.as_ptr()) }, ESP_OK);
+
+        let fb = unsafe { std::slice::from_raw_parts(fb_ptr(), EPD_FB_BYTES) };
+        let row_bytes = EPD_WIDTH / 8;
+        assert_eq!(fb[4 * row_bytes + 1], 0b1010_1010);
+        assert_eq!(fb[4 * row_bytes + 2], 0b1000_0000);
+        assert_eq!(fb[5 * row_bytes + 1], 0b0101_0101);
+        assert_eq!(fb[5 * row_bytes + 2], 0b0000_0000);
+    }
+
+    #[test]
+    fn test_flush_keeps_aligned_full_width_rows_unchanged() {
+        reset_state();
+        state_mut().initialized = true;
+
+        let area = HalArea { x1: 0, y1: 7, x2: 239, y2: 8 };
+        let mut data = [0u8; 60];
+        data[..30].fill(0xA5);
+        data[30..].fill(0x5A);
+        assert_eq!(unsafe { gdeq031t10_flush(&area, data.as_ptr()) }, ESP_OK);
+
+        let fb = unsafe { std::slice::from_raw_parts(fb_ptr(), EPD_FB_BYTES) };
+        let row_bytes = EPD_WIDTH / 8;
+        assert_eq!(&fb[7 * row_bytes..8 * row_bytes], &data[..30]);
+        assert_eq!(&fb[8 * row_bytes..9 * row_bytes], &data[30..]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #50

## Root cause

The e-paper partial-flush paths treated a multi-row 1-bpp rectangle as one continuous bitstream. The actual input contract pads every source row to `(width + 7) / 8` bytes, so non-byte-aligned widths caused all rows after the first to read padding or neighboring-row bits.

## Changes

- calculate the byte stride once and select each source row before extracting its pixels
- apply the same row-relative algorithm to the Rust implementation and the still-shipped legacy C driver
- preserve the C full-width `memcpy` fast path unchanged
- add direct host coverage for the internal legacy C blitter
- add Rust framebuffer regressions for 3x2, 9x2, and aligned 240x2 updates

The C helper is private and exists only to test the currently shipped adapter. This adds no public C API and does not expand the C architecture; it can be removed with the legacy driver during the Rust migration.

## Verification

- regression-first: both 3x2 and 9x2 Rust tests failed against the vulnerable implementation on the second row
- focused C packed-blit test passes with strict warnings
- focused Rust 3x2, 9x2, and aligned-width tests pass
- full Rust host suite: 1,342 passed, 0 failed
- full ESP32-S3 firmware build passes; application image has 0x44010 bytes (11%) free
- H2 is intentionally excluded from scope

Repository-wide `cargo fmt --check` remains red on pre-existing formatting drift across unrelated Rust modules; this PR does not reformat those files.
