### PR TITLE
Run simulator unit tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,15 +44,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsdl2-dev pkg-config cmake build-essential libcurl4-openssl-dev
 
-      # Note: On-target ESP-IDF Unity tests require hardware.
-      # This job verifies the test code compiles and the simulator builds.
-      - name: Verify test compilation
-        run: |
-          echo "Test files:"
-          find components/test_thistle -name "*.c" -exec wc -l {} + | sort -n
-          echo ""
-          echo "Total test cases (approximate):"
-          grep -r "TEST_CASE" components/test_thistle/ | wc -l
+      - name: Configure simulator unit tests
+        run: cmake -S simulator -B simulator/build-tests
+
+      - name: Build simulator unit tests
+        run: cmake --build simulator/build-tests --target thistle_sim_tests --parallel
+
+      - name: Run simulator unit tests
+        run: ./simulator/build-tests/thistle_sim_tests
 
       - name: Test SMS command framing validation
         run: |


### PR DESCRIPTION
Closes #26

## Change

Replace count-only reporting in the host unit-test job with three enforceable gates:

- configure the simulator build
- build the existing `thistle_sim_tests` target
- execute the resulting test binary

Any configure, compile, link, or test failure now fails the job. The existing README commands already describe the same target and remain aligned.

## Verification

- configured the simulator in a fresh isolated worktree
- built only `thistle_sim_tests`
- executed the binary: 17/17 tests passed
- H2 is intentionally excluded from scope
