### PR TITLE
ci: publish signed standalone driver packages

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -1,21 +1,37 @@
-name: Build & Publish Apps
+name: Build & Publish Packages
 
 on:
   push:
     branches: [main]
     paths:
       - 'standalone_apps/**'
+      - 'standalone_drivers/**'
       - 'app_sdk/**'
       - 'driver_sdk/**'
+      - '.github/workflows/apps.yml'
       - 'tools/sign_elf.py'
       - 'tools/build_catalog.py'
+      - 'tools/test_build_catalog.py'
+      - 'tools/test_package_workflow.py'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'standalone_apps/**'
+      - 'standalone_drivers/**'
+      - 'app_sdk/**'
+      - 'driver_sdk/**'
+      - '.github/workflows/apps.yml'
+      - 'tools/sign_elf.py'
+      - 'tools/build_catalog.py'
+      - 'tools/test_build_catalog.py'
+      - 'tools/test_package_workflow.py'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  build-apps:
+  build-packages:
     runs-on: ubuntu-latest
     container: espressif/idf:v5.5
     strategy:
@@ -36,59 +52,95 @@ jobs:
           . $IDF_PATH/export.sh
           idf.py set-target "$TARGET_ARCH"
 
-      - name: Build standalone apps
+      - name: Build standalone packages
         env:
           TARGET_ARCH: ${{ matrix.arch }}
+        shell: bash
         run: |
-          set -e
+          set -euo pipefail
           . $IDF_PATH/export.sh
           mkdir -p "artifacts/$TARGET_ARCH"
 
-          for app_dir in standalone_apps/*/; do
-            app_name=$(basename "$app_dir")
-            echo "Building $app_name for $TARGET_ARCH..."
+          build_packages() {
+            local package_root="$1"
+            local package_type="$2"
+            local expected_suffix="$3"
+            local package_count=0
 
-            mkdir -p "$app_dir/build"
-            cd "$app_dir/build"
-            cmake .. -DCMAKE_TOOLCHAIN_FILE="$IDF_PATH/tools/cmake/toolchain-${TARGET_ARCH}.cmake"
-            cmake --build . --parallel
-            cd -
+            for package_dir in "$package_root"/*/; do
+              [ -d "$package_dir" ] || continue
+              package_count=$((package_count + 1))
+              local package_name
+              package_name=$(basename "$package_dir")
+              local manifest="$package_dir/manifest.json"
+              test -f "$manifest"
 
-            # Copy artifacts
-            mkdir -p "artifacts/$TARGET_ARCH"
-            elf=$(find "$app_dir/build" -name "*.app.elf" | head -1)
-            if [ -n "$elf" ]; then
-              cp "$elf" "artifacts/$TARGET_ARCH/"
-              if [ -f "$app_dir/manifest.json" ]; then
-                cp "$app_dir/manifest.json" "artifacts/$TARGET_ARCH/${app_name}.manifest.json"
+              local manifest_type
+              local entry
+              manifest_type=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["type"])' "$manifest")
+              entry=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["entry"])' "$manifest")
+              test "$manifest_type" = "$package_type"
+              case "$entry" in
+                *"$expected_suffix") ;;
+                *) echo "::error::$manifest declares unexpected entry $entry"; exit 1 ;;
+              esac
+
+              echo "Building $package_type $package_name for $TARGET_ARCH..."
+              local build_dir="$package_dir/build-$TARGET_ARCH"
+              cmake -S "$package_dir" -B "$build_dir" \
+                -DCMAKE_TOOLCHAIN_FILE="$IDF_PATH/tools/cmake/toolchain-${TARGET_ARCH}.cmake"
+              cmake --build "$build_dir" --parallel
+
+              local elf="$build_dir/$entry"
+              if [ ! -f "$elf" ]; then
+                echo "::error::$package_name did not produce declared artifact $entry"
+                exit 1
               fi
-            else
-              echo "::warning::No .app.elf found for $app_name"
+              local destination="artifacts/$TARGET_ARCH/${package_type}s/$package_name"
+              mkdir -p "$destination"
+              cp "$elf" "$destination/$entry"
+              cp "$manifest" "$destination/manifest.json"
+            done
+
+            if [ "$package_count" -eq 0 ]; then
+              echo "::error::No declared $package_type packages found in $package_root"
+              exit 1
             fi
-          done
+          }
+
+          build_packages standalone_apps app .app.elf
+          build_packages standalone_drivers driver .drv.elf
 
       - name: Sign artifacts
-        if: env.SIGNING_KEY != ''
         env:
-          SIGNING_KEY: ${{ secrets.THISTLE_SIGNING_KEY }}
+          PRODUCTION_SIGNING_KEY: ${{ secrets.THISTLE_SIGNING_KEY }}
           TARGET_ARCH: ${{ matrix.arch }}
+        shell: bash
         run: |
-          pip install pynacl
-          shopt -s nullglob
-          for elf in "artifacts/$TARGET_ARCH/"*.app.elf; do
+          set -euo pipefail
+          python3 -m pip install -r tools/requirements.txt
+          SIGNING_KEY="$PRODUCTION_SIGNING_KEY"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            SIGNING_KEY=$(python3 -c 'from nacl.signing import SigningKey; print(SigningKey.generate().encode().hex())')
+          elif [ -z "$SIGNING_KEY" ]; then
+            echo "::error::THISTLE_SIGNING_KEY is required for published packages"
+            exit 1
+          fi
+          while IFS= read -r -d '' elf; do
             python3 tools/sign_elf.py sign "$elf" --key "$SIGNING_KEY"
-          done
+          done < <(find "artifacts/$TARGET_ARCH" -type f \
+            \( -name '*.app.elf' -o -name '*.drv.elf' \) -print0)
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: apps-${{ matrix.arch }}
+          name: packages-${{ matrix.arch }}
           path: artifacts/${{ matrix.arch }}/
 
   publish-catalog:
-    needs: build-apps
+    needs: build-packages
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
       pages: write
@@ -102,20 +154,23 @@ jobs:
           path: all-artifacts/
 
       - name: Merge artifacts
+        shell: bash
         run: |
+          set -euo pipefail
           mkdir -p publish/apps
-          cp -r all-artifacts/*/. publish/apps/
+          for artifact_dir in all-artifacts/packages-*; do
+            arch=${artifact_dir##*-}
+            mkdir -p "publish/apps/$arch"
+            cp -r "$artifact_dir"/. "publish/apps/$arch/"
+          done
 
       - name: Generate catalog
         run: |
-          pip install pynacl
+          set -euo pipefail
           python3 tools/build_catalog.py publish/apps \
             --base-url "https://wan0net.github.io/thistle-apps/apps" \
             --output publish/catalog.json \
-            --merge appstore-site/catalog.json 2>/dev/null || true
-
-          # Copy any existing static assets
-          cp -r appstore-site/* publish/ 2>/dev/null || true
+            --require-signatures
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -118,16 +118,20 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python3 -m pip install -r tools/requirements.txt
+          apt-get update
+          apt-get install -y python3-venv
+          python3 -m venv /tmp/thistle-package-signing-venv
+          /tmp/thistle-package-signing-venv/bin/pip install -r tools/requirements.txt
           SIGNING_KEY="$PRODUCTION_SIGNING_KEY"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            SIGNING_KEY=$(python3 -c 'from nacl.signing import SigningKey; print(SigningKey.generate().encode().hex())')
+            SIGNING_KEY=$(/tmp/thistle-package-signing-venv/bin/python -c 'from nacl.signing import SigningKey; print(SigningKey.generate().encode().hex())')
           elif [ -z "$SIGNING_KEY" ]; then
             echo "::error::THISTLE_SIGNING_KEY is required for published packages"
             exit 1
           fi
           while IFS= read -r -d '' elf; do
-            python3 tools/sign_elf.py sign "$elf" --key "$SIGNING_KEY"
+            /tmp/thistle-package-signing-venv/bin/python \
+              tools/sign_elf.py sign "$elf" --key "$SIGNING_KEY"
           done < <(find "artifacts/$TARGET_ARCH" -type f \
             \( -name '*.app.elf' -o -name '*.drv.elf' \) -print0)
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,6 +121,11 @@ jobs:
           python3 -m pip install -r tools/requirements.txt
           python3 tools/test_sign.py
 
+      - name: Test standalone package publication
+        run: |
+          python3 tools/test_build_catalog.py
+          python3 tools/test_package_workflow.py
+
       - name: Test release input and provenance validation
         run: python3 tools/test_validate_release.py
 

--- a/tools/build_catalog.py
+++ b/tools/build_catalog.py
@@ -3,16 +3,16 @@
 
 import json
 import hashlib
-import sys
 import argparse
 from datetime import date
 from pathlib import Path
 
 
-def scan_artifacts(artifact_dir: str, base_url: str) -> list:
+def scan_artifacts(artifact_dir: str, base_url: str,
+                   require_signatures: bool = False) -> list:
     """Scan directory for .app.elf/.drv.elf + manifest.json pairs."""
     entries = []
-    artifact_path = Path(artifact_dir)
+    artifact_path = Path(artifact_dir).resolve()
 
     manifest_files = sorted(
         set(list(artifact_path.glob("**/manifest.json"))
@@ -25,12 +25,25 @@ def scan_artifacts(artifact_dir: str, base_url: str) -> list:
         # Find corresponding ELF
         elf_name = manifest.get("entry", "")
         if not elf_name:
-            continue
-        elf_path = manifest_file.parent / elf_name
+            raise ValueError(f"Manifest has no entry: {manifest_file}")
+        elf_path = (manifest_file.parent / elf_name).resolve()
+        try:
+            rel_path = elf_path.relative_to(artifact_path)
+        except ValueError as exc:
+            raise ValueError(
+                f"Manifest entry escapes artifact directory: {manifest_file}"
+            ) from exc
         if not elf_path.exists():
-            print(f"Warning: ELF not found for {manifest_file}: {elf_name}",
-                  file=sys.stderr)
-            continue
+            raise FileNotFoundError(
+                f"ELF not found for {manifest_file}: {elf_name}"
+            )
+
+        entry_type = manifest.get("type", "app")
+        expected_suffix = ".drv.elf" if entry_type == "driver" else ".app.elf"
+        if not elf_name.endswith(expected_suffix):
+            raise ValueError(
+                f"{entry_type} manifest has invalid entry suffix: {manifest_file}"
+            )
 
         # Compute SHA-256
         elf_data = elf_path.read_bytes()
@@ -40,18 +53,14 @@ def scan_artifacts(artifact_dir: str, base_url: str) -> list:
         # Check for signature
         sig_path = elf_path.with_suffix(elf_path.suffix + ".sig")
         has_sig = sig_path.exists()
+        if require_signatures and not has_sig:
+            raise FileNotFoundError(f"Signature not found for {elf_path}")
 
         # Build relative URL path
-        try:
-            rel_path = elf_path.relative_to(artifact_path)
-        except ValueError:
-            print(f"Warning: skipping {manifest_file} — entry path outside artifact dir", file=sys.stderr)
-            continue
-        elf_url = f"{base_url}/{rel_path}"
-        sig_url = f"{base_url}/{rel_path}.sig" if has_sig else ""
+        elf_url = f"{base_url.rstrip('/')}/{rel_path.as_posix()}"
+        sig_url = f"{elf_url}.sig" if has_sig else ""
 
         # Map manifest fields to catalog entry
-        entry_type = manifest.get("type", "app")
         permissions = manifest.get("permissions", [])
         if isinstance(permissions, list):
             permissions = ",".join(permissions)
@@ -108,10 +117,13 @@ def main():
     parser.add_argument("--merge",
                         help="Existing catalog to merge with "
                              "(preserves ratings/downloads)")
+    parser.add_argument("--require-signatures", action="store_true",
+                        help="Fail if any catalogued ELF has no signature")
 
     args = parser.parse_args()
 
-    entries = scan_artifacts(args.artifact_dir, args.base_url)
+    entries = scan_artifacts(args.artifact_dir, args.base_url,
+                             require_signatures=args.require_signatures)
 
     # Merge with existing catalog to preserve ratings/downloads
     if args.merge and Path(args.merge).exists():

--- a/tools/test_build_catalog.py
+++ b/tools/test_build_catalog.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Regression tests for standalone package catalog publication."""
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from build_catalog import scan_artifacts
+
+
+class BuildCatalogTests(unittest.TestCase):
+    def write_package(self, root: Path, kind: str, package_id: str) -> tuple[Path, bytes]:
+        package_dir = root / "esp32s3" / f"{kind}s" / package_id
+        package_dir.mkdir(parents=True)
+        suffix = ".app.elf" if kind == "app" else ".drv.elf"
+        elf_name = f"{package_id}{suffix}"
+        elf_data = f"ELF:{package_id}".encode()
+        (package_dir / elf_name).write_bytes(elf_data)
+        (package_dir / f"{elf_name}.sig").write_bytes(b"s" * 64)
+        (package_dir / "manifest.json").write_text(json.dumps({
+            "id": f"com.thistle.{package_id}",
+            "type": kind,
+            "name": package_id,
+            "version": "1.0.0",
+            "arch": "esp32s3",
+            "entry": elf_name,
+        }))
+        return package_dir, elf_data
+
+    def test_signed_apps_and_drivers_are_catalogued_with_qualified_urls(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, app_data = self.write_package(root, "app", "hello")
+            _, driver_data = self.write_package(root, "driver", "keyboard")
+
+            entries = scan_artifacts(str(root), "https://example.test/apps",
+                                     require_signatures=True)
+
+            self.assertEqual({entry["type"] for entry in entries}, {"app", "driver"})
+            by_id = {entry["id"]: entry for entry in entries}
+            self.assertEqual(by_id["com.thistle.hello"]["sha256"],
+                             hashlib.sha256(app_data).hexdigest())
+            self.assertEqual(by_id["com.thistle.keyboard"]["sha256"],
+                             hashlib.sha256(driver_data).hexdigest())
+            for entry in entries:
+                self.assertTrue(entry["is_signed"])
+                self.assertIn("/esp32s3/", entry["url"])
+                self.assertEqual(entry["sig_url"], f'{entry["url"]}.sig')
+                relative_url = entry["url"].removeprefix("https://example.test/apps/")
+                self.assertTrue((root / relative_url).is_file())
+                self.assertTrue((root / f"{relative_url}.sig").is_file())
+
+    def test_missing_declared_elf_fails_catalog_generation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_dir = root / "esp32s3" / "drivers" / "missing"
+            package_dir.mkdir(parents=True)
+            (package_dir / "manifest.json").write_text(json.dumps({
+                "id": "com.thistle.missing",
+                "type": "driver",
+                "entry": "missing.drv.elf",
+            }))
+
+            with self.assertRaises(FileNotFoundError):
+                scan_artifacts(str(root), "https://example.test/apps")
+
+    def test_unsigned_package_fails_when_signatures_are_required(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_dir, _ = self.write_package(root, "driver", "keyboard")
+            (package_dir / "keyboard.drv.elf.sig").unlink()
+
+            with self.assertRaises(FileNotFoundError):
+                scan_artifacts(str(root), "https://example.test/apps",
+                               require_signatures=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_package_workflow.py
+++ b/tools/test_package_workflow.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Guard the standalone package workflow against silently dropping drivers."""
+
+import unittest
+from pathlib import Path
+
+
+class PackageWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = Path(".github/workflows/apps.yml").read_text()
+
+    def test_driver_changes_trigger_the_workflow(self):
+        self.assertIn("standalone_drivers/**", self.workflow)
+
+    def test_apps_and_drivers_are_built_and_signed(self):
+        self.assertIn("standalone_apps", self.workflow)
+        self.assertIn("standalone_drivers", self.workflow)
+        self.assertIn("*.app.elf", self.workflow)
+        self.assertIn("*.drv.elf", self.workflow)
+
+    def test_publication_is_strict_and_architecture_qualified(self):
+        self.assertIn("--require-signatures", self.workflow)
+        self.assertIn('publish/apps/$arch', self.workflow)
+        self.assertNotIn("2>/dev/null || true", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #59

## What changed
- trigger package CI for standalone driver changes and build declared apps and drivers
- fail when a manifest has no matching ELF, and sign both `.app.elf` and `.drv.elf` artifacts
- publish architecture-qualified package paths and require signatures during catalog generation
- run package builds on pull requests with ephemeral signatures; production publication requires `THISTLE_SIGNING_KEY`
- add regression coverage for app/driver catalog entries, hashes, signatures, URLs, and missing artifacts

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python3 tools/test_build_catalog.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 tools/test_package_workflow.py`
- workflow YAML parse
- `git diff --check`

## Notes
- The package pipeline is artifact- and manifest-driven, so it does not introduce a new C API and can publish Rust-built standalone drivers as the C implementation is retired.
- Local ESP-IDF package compilation was unavailable because the Docker daemon is not running; the PR package workflow is the build gate.