### PR TITLE
ci: preserve package architecture during publication

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -139,7 +139,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: packages-${{ matrix.arch }}
-          path: artifacts/${{ matrix.arch }}/
+          path: artifacts/
 
   publish-catalog:
     needs: build-packages
@@ -156,17 +156,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: all-artifacts/
+          merge-multiple: true
 
       - name: Merge artifacts
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p publish/apps
-          for artifact_dir in all-artifacts/packages-*; do
-            arch=${artifact_dir##*-}
-            mkdir -p "publish/apps/$arch"
-            cp -r "$artifact_dir"/. "publish/apps/$arch/"
-          done
+          cp -r all-artifacts/. publish/apps/
 
       - name: Generate catalog
         run: |

--- a/tools/test_package_workflow.py
+++ b/tools/test_package_workflow.py
@@ -21,7 +21,10 @@ class PackageWorkflowTests(unittest.TestCase):
 
     def test_publication_is_strict_and_architecture_qualified(self):
         self.assertIn("--require-signatures", self.workflow)
-        self.assertIn('publish/apps/$arch', self.workflow)
+        self.assertIn('artifacts/$TARGET_ARCH', self.workflow)
+        self.assertIn('path: artifacts/', self.workflow)
+        self.assertIn('merge-multiple: true', self.workflow)
+        self.assertIn('all-artifacts/. publish/apps/', self.workflow)
         self.assertNotIn("2>/dev/null || true", self.workflow)
 
 


### PR DESCRIPTION
Follow-up to #110.

The production run built and signed all ESP32-S3 app and driver artifacts, then exposed that `download-artifact@v8` flattened the only downloaded artifact into the configured directory. The merge step expected an extra artifact-name directory and failed.

## Fix
- upload the architecture root (`artifacts/`) instead of only its contents
- explicitly merge downloaded matrix artifacts
- copy the resulting architecture directories into the Pages package root
- extend the workflow regression contract for this layout

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python3 tools/test_package_workflow.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 tools/test_build_catalog.py`
- workflow YAML parse
- `git diff --check`

The production Pages run will be monitored after merge and live catalog URLs will be checked.