### PR TITLE
ci: publish packages to canonical app catalog

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -146,11 +146,16 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
-      contents: write
-      pages: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Check out canonical app catalog
+        uses: actions/checkout@v6
+        with:
+          repository: wan0net/thistle-apps
+          path: existing-app-catalog
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8
@@ -171,11 +176,15 @@ jobs:
           python3 tools/build_catalog.py publish/apps \
             --base-url "https://wan0net.github.io/thistle-apps/apps" \
             --output publish/catalog.json \
+            --merge existing-app-catalog/catalog.json \
             --require-signatures
 
-      - name: Deploy to GitHub Pages
+      - name: Deploy to canonical app catalog
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.THISTLE_APPS_DEPLOY_KEY }}
+          external_repository: wan0net/thistle-apps
+          publish_branch: main
           publish_dir: ./publish
           destination_dir: .
+          keep_files: true

--- a/tools/build_catalog.py
+++ b/tools/build_catalog.py
@@ -104,6 +104,33 @@ def scan_artifacts(artifact_dir: str, base_url: str,
     return entries
 
 
+def merge_catalog_entries(entries: list, existing_entries: list) -> list:
+    """Preserve existing packages and carry usage metadata onto rebuilt ones."""
+    existing_map = {
+        entry.get("id", ""): entry
+        for entry in existing_entries
+        if entry.get("id")
+    }
+    merged = []
+    rebuilt_ids = set()
+    for entry in entries:
+        package_id = entry.get("id", "")
+        rebuilt_ids.add(package_id)
+        old = existing_map.get(package_id, {})
+        entry["rating"] = old.get("rating", entry.get("rating", 0))
+        entry["rating_count"] = old.get(
+            "rating_count", entry.get("rating_count", 0)
+        )
+        entry["downloads"] = old.get("downloads", entry.get("downloads", 0))
+        merged.append(entry)
+
+    merged.extend(
+        entry for entry in existing_entries
+        if entry.get("id") not in rebuilt_ids
+    )
+    return merged
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Generate ThistleOS app catalog"
@@ -125,21 +152,15 @@ def main():
     entries = scan_artifacts(args.artifact_dir, args.base_url,
                              require_signatures=args.require_signatures)
 
-    # Merge with existing catalog to preserve ratings/downloads
-    if args.merge and Path(args.merge).exists():
-        existing = json.loads(Path(args.merge).read_text())
-        existing_map = {e["id"]: e for e in existing.get("entries", [])}
-        for entry in entries:
-            if entry["id"] in existing_map:
-                old = existing_map[entry["id"]]
-                entry["rating"] = old.get("rating", 0)
-                entry["rating_count"] = old.get("rating_count", 0)
-                entry["downloads"] = old.get("downloads", 0)
-
-    # Set updated date
+    # Set the publication date only on packages rebuilt in this run.
     today = date.today().isoformat()
     for entry in entries:
         entry["updated"] = today
+
+    # Preserve packages not rebuilt here and retain their usage metadata.
+    if args.merge and Path(args.merge).exists():
+        existing = json.loads(Path(args.merge).read_text())
+        entries = merge_catalog_entries(entries, existing.get("entries", []))
 
     catalog = {
         "version": 1,

--- a/tools/test_build_catalog.py
+++ b/tools/test_build_catalog.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from build_catalog import scan_artifacts
+from build_catalog import merge_catalog_entries, scan_artifacts
 
 
 class BuildCatalogTests(unittest.TestCase):
@@ -75,6 +75,25 @@ class BuildCatalogTests(unittest.TestCase):
             with self.assertRaises(FileNotFoundError):
                 scan_artifacts(str(root), "https://example.test/apps",
                                require_signatures=True)
+
+    def test_merge_preserves_existing_packages_and_download_stats(self):
+        new_entries = [{"id": "com.thistle.hello", "rating": 0,
+                        "rating_count": 0, "downloads": 0}]
+        existing_entries = [
+            {"id": "com.thistle.hello", "rating": 4.5,
+             "rating_count": 12, "downloads": 99},
+            {"id": "com.thistle.legacy", "type": "app",
+             "url": "https://example.test/legacy.app.elf"},
+        ]
+
+        merged = merge_catalog_entries(new_entries, existing_entries)
+
+        by_id = {entry["id"]: entry for entry in merged}
+        self.assertEqual(set(by_id), {"com.thistle.hello", "com.thistle.legacy"})
+        self.assertEqual(by_id["com.thistle.hello"]["rating"], 4.5)
+        self.assertEqual(by_id["com.thistle.hello"]["downloads"], 99)
+        self.assertEqual(by_id["com.thistle.legacy"]["url"],
+                         "https://example.test/legacy.app.elf")
 
 
 if __name__ == "__main__":

--- a/tools/test_package_workflow.py
+++ b/tools/test_package_workflow.py
@@ -27,6 +27,14 @@ class PackageWorkflowTests(unittest.TestCase):
         self.assertIn('all-artifacts/. publish/apps/', self.workflow)
         self.assertNotIn("2>/dev/null || true", self.workflow)
 
+    def test_canonical_catalog_repository_is_the_deploy_target(self):
+        self.assertIn('repository: wan0net/thistle-apps', self.workflow)
+        self.assertIn('--merge existing-app-catalog/catalog.json', self.workflow)
+        self.assertIn('external_repository: wan0net/thistle-apps', self.workflow)
+        self.assertIn('deploy_key: ${{ secrets.THISTLE_APPS_DEPLOY_KEY }}',
+                      self.workflow)
+        self.assertIn('keep_files: true', self.workflow)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #59

Live verification of #110/#111 showed the package deploy was writing to the ThistleOS Pages target while every generated URL points to the separate `wan0net/thistle-apps` site. This change makes that ownership boundary explicit.

## What changed
- deploy packages and `catalog.json` to `wan0net/thistle-apps` with a write-enabled deploy key scoped only to that repository
- store the private key as the `THISTLE_APPS_DEPLOY_KEY` Actions secret in `wan0net/thistle-os`
- merge the existing canonical catalog so manually published apps, firmware, drivers, and usage statistics are preserved
- keep existing files in the catalog repository during deployment
- add regression coverage for canonical-repository targeting and non-destructive catalog merges

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python3 tools/test_build_catalog.py` (4 tests)
- `PYTHONDONTWRITEBYTECODE=1 python3 tools/test_package_workflow.py` (4 tests)
- workflow YAML parse
- `git diff --check`
- deploy key readback: `ThistleOS package publisher`, write-enabled only on `wan0net/thistle-apps`
- Actions secret readback confirms `THISTLE_APPS_DEPLOY_KEY` exists without exposing its value

The production workflow will be monitored after merge, followed by live catalog, ELF, signature, and SHA-256 readback.