### PR TITLE
ci: keep WASM and catalog builds migration-safe

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,16 @@ name: Deploy Pages (Docs + WASM Simulator)
 on:
   push:
     branches: [main]
+  pull_request:
+    paths:
+      - '.github/workflows/pages.yml'
+      - 'components/apps_builtin/**'
+      - 'components/kernel/**'
+      - 'components/kernel_rs/**'
+      - 'components/thistle_hal/**'
+      - 'components/ui/**'
+      - 'simulator/**'
+      - 'wasm/**'
 
 permissions:
   contents: read
@@ -114,6 +124,7 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
+    if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,6 +126,7 @@ jobs:
           python3 tools/test_build_catalog.py
           python3 tools/test_package_workflow.py
           python3 tools/test_target_matrix.py
+          python3 tools/test_wasm_migration.py
           python3 tools/test_validate_package_matrix.py
 
       - name: Test release input and provenance validation

--- a/tools/test_validate_package_matrix.py
+++ b/tools/test_validate_package_matrix.py
@@ -38,6 +38,20 @@ class PackageMatrixValidationTests(unittest.TestCase):
         self.assertTrue(any("not signed" in error for error in errors))
         self.assertTrue(any("esp32c6: missing" in error for error in errors))
 
+    def test_legacy_unqualified_entries_do_not_break_current_matrix(self):
+        entries = [
+            entry(arch, package_type)
+            for arch in SUPPORTED_ARCHES
+            for package_type in ["app", "driver"]
+        ]
+        entries.append({
+            "id": "com.thistle.legacy",
+            "type": "app",
+            "url": "https://example.test/apps/legacy.app.elf",
+        })
+
+        self.assertEqual(validate_entries(entries), [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_wasm_migration.py
+++ b/tools/test_wasm_migration.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Regression tests for the WASM simulator during the C-to-Rust app migration."""
+
+from pathlib import Path
+import unittest
+
+
+class WasmMigrationTests(unittest.TestCase):
+    def setUp(self):
+        self.cmake = Path("wasm/CMakeLists.txt").read_text()
+        self.main = Path("wasm/main.c").read_text()
+        self.workflow = Path(".github/workflows/pages.yml").read_text()
+
+    def test_cmake_filters_sources_removed_after_rust_migration(self):
+        self.assertIn("set(THISTLE_WASM_SRCS)", self.cmake)
+        self.assertIn('if(EXISTS "${source}")', self.cmake)
+        self.assertIn(
+            "add_executable(thistle_wasm ${WASM_SRCS} ${THISTLE_WASM_SRCS} ${LVGL_SRCS})",
+            self.cmake,
+        )
+
+    def test_deleted_c_apps_are_guarded_in_browser_entrypoint(self):
+        migrated_apps = {
+            "FILEMGR": "filemgr_app_register();",
+            "READER": "reader_app_register();",
+            "NAVIGATOR": "navigator_app_register();",
+            "NOTES": "notes_app_register();",
+            "APPSTORE": "appstore_app_register();",
+            "WIFISCANNER": "wifiscanner_app_register();",
+            "FLASHLIGHT": "flashlight_app_register();",
+            "WEATHER": "weather_app_register();",
+            "VAULT": "vault_app_register();",
+        }
+        for flag, registration in migrated_apps.items():
+            with self.subTest(flag=flag):
+                guard = f"#if THISTLE_HAVE_{flag}"
+                self.assertIn(guard, self.main)
+                self.assertGreater(self.main.index(registration), self.main.index(guard))
+
+    def test_pull_requests_build_wasm_without_deploying_pages(self):
+        self.assertIn("pull_request:", self.workflow)
+        self.assertIn("if: github.event_name == 'push'", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate_package_matrix.py
+++ b/tools/validate_package_matrix.py
@@ -19,6 +19,11 @@ def validate_entries(entries: list[dict]) -> list[str]:
             continue
         package_id = entry.get("id", "<missing id>")
         arch = entry.get("arch")
+        # Preserve pre-matrix catalog entries without pretending they target a
+        # specific CPU. They remain installable for legacy clients, but do not
+        # count toward (or weaken) current architecture coverage.
+        if not arch:
+            continue
         if arch not in SUPPORTED_ARCHES:
             errors.append(f"{package_id}: unsupported architecture {arch!r}")
             continue

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -49,6 +49,7 @@ set(THISTLE_SRCS
     ${THISTLE_DIR}/components/apps_builtin/appstore/appstore_app.c
     ${THISTLE_DIR}/components/apps_builtin/appstore/appstore_ui.c
     ${THISTLE_DIR}/components/apps_builtin/assistant/assistant_app.c
+    ${THISTLE_DIR}/components/apps_builtin/assistant/assistant_request.c
     ${THISTLE_DIR}/components/apps_builtin/assistant/assistant_ui.c
     ${THISTLE_DIR}/components/apps_builtin/wifiscanner/wifiscanner_app.c
     ${THISTLE_DIR}/components/apps_builtin/wifiscanner/wifiscanner_ui.c
@@ -61,6 +62,41 @@ set(THISTLE_SRCS
     ${THISTLE_DIR}/components/apps_builtin/vault/vault_app.c
     ${THISTLE_DIR}/components/apps_builtin/vault/vault_ui.c
 )
+
+# Built-in apps are being migrated from compiled-in C to signed Rust ELFs.
+# Keep the browser simulator buildable throughout that migration: only compile
+# source files that still exist and expose availability flags to main.c.
+function(thistle_set_optional_app_flag flag source)
+    if(EXISTS "${THISTLE_DIR}/${source}")
+        set(${flag} 1 PARENT_SCOPE)
+    else()
+        set(${flag} 0 PARENT_SCOPE)
+    endif()
+endfunction()
+
+thistle_set_optional_app_flag(THISTLE_HAVE_LAUNCHER "components/apps_builtin/launcher/launcher_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_SETTINGS "components/apps_builtin/settings/settings_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_FILEMGR "components/apps_builtin/file_manager/filemgr_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_READER "components/apps_builtin/reader/reader_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_MESSENGER "components/apps_builtin/messenger/messenger_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_NAVIGATOR "components/apps_builtin/navigator/navigator_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_NOTES "components/apps_builtin/notes/notes_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_APPSTORE "components/apps_builtin/appstore/appstore_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_ASSISTANT "components/apps_builtin/assistant/assistant_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_WIFISCANNER "components/apps_builtin/wifiscanner/wifiscanner_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_FLASHLIGHT "components/apps_builtin/flashlight/flashlight_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_WEATHER "components/apps_builtin/weather/weather_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_TERMINAL "components/apps_builtin/terminal/terminal_app.c")
+thistle_set_optional_app_flag(THISTLE_HAVE_VAULT "components/apps_builtin/vault/vault_app.c")
+
+set(THISTLE_WASM_SRCS)
+foreach(source IN LISTS THISTLE_SRCS)
+    if(EXISTS "${source}")
+        list(APPEND THISTLE_WASM_SRCS "${source}")
+    else()
+        message(STATUS "Skipping migrated WASM app source: ${source}")
+    endif()
+endforeach()
 
 # WASM-specific sources
 set(SIM_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../simulator")
@@ -91,7 +127,7 @@ set(WASM_SRCS
     ${SIM_DIR}/platform/sim_vfs.c
 )
 
-add_executable(thistle_wasm ${WASM_SRCS} ${THISTLE_SRCS} ${LVGL_SRCS})
+add_executable(thistle_wasm ${WASM_SRCS} ${THISTLE_WASM_SRCS} ${LVGL_SRCS})
 set_target_properties(thistle_wasm PROPERTIES SUFFIX ".html")
 
 # Emscripten SDL2 — auto-provided, no system install needed
@@ -125,6 +161,20 @@ target_compile_definitions(thistle_wasm PRIVATE
     LV_COLOR_DEPTH=16
     SIMULATOR_BUILD=1
     WASM_BUILD=1
+    THISTLE_HAVE_LAUNCHER=${THISTLE_HAVE_LAUNCHER}
+    THISTLE_HAVE_SETTINGS=${THISTLE_HAVE_SETTINGS}
+    THISTLE_HAVE_FILEMGR=${THISTLE_HAVE_FILEMGR}
+    THISTLE_HAVE_READER=${THISTLE_HAVE_READER}
+    THISTLE_HAVE_MESSENGER=${THISTLE_HAVE_MESSENGER}
+    THISTLE_HAVE_NAVIGATOR=${THISTLE_HAVE_NAVIGATOR}
+    THISTLE_HAVE_NOTES=${THISTLE_HAVE_NOTES}
+    THISTLE_HAVE_APPSTORE=${THISTLE_HAVE_APPSTORE}
+    THISTLE_HAVE_ASSISTANT=${THISTLE_HAVE_ASSISTANT}
+    THISTLE_HAVE_WIFISCANNER=${THISTLE_HAVE_WIFISCANNER}
+    THISTLE_HAVE_FLASHLIGHT=${THISTLE_HAVE_FLASHLIGHT}
+    THISTLE_HAVE_WEATHER=${THISTLE_HAVE_WEATHER}
+    THISTLE_HAVE_TERMINAL=${THISTLE_HAVE_TERMINAL}
+    THISTLE_HAVE_VAULT=${THISTLE_HAVE_VAULT}
     CONFIG_LOG_DEFAULT_LEVEL=3
     THISTLE_SDCARD_PATH="/thistle_sdcard"
 )

--- a/wasm/main.c
+++ b/wasm/main.c
@@ -20,20 +20,48 @@
 #include "sim_vfs.h"
 
 /* App registration headers — must match simulator/main.c */
+#if THISTLE_HAVE_LAUNCHER
 #include "launcher/launcher_app.h"
+#endif
+#if THISTLE_HAVE_SETTINGS
 #include "settings/settings_app.h"
+#endif
+#if THISTLE_HAVE_FILEMGR
 #include "file_manager/filemgr_app.h"
+#endif
+#if THISTLE_HAVE_READER
 #include "reader/reader_app.h"
+#endif
+#if THISTLE_HAVE_MESSENGER
 #include "messenger/messenger_app.h"
+#endif
+#if THISTLE_HAVE_NAVIGATOR
 #include "navigator/navigator_app.h"
+#endif
+#if THISTLE_HAVE_NOTES
 #include "notes/notes_app.h"
+#endif
+#if THISTLE_HAVE_APPSTORE
 #include "appstore/appstore_app.h"
+#endif
+#if THISTLE_HAVE_ASSISTANT
 #include "assistant/assistant_app.h"
+#endif
+#if THISTLE_HAVE_WIFISCANNER
 #include "wifiscanner/wifiscanner_app.h"
+#endif
+#if THISTLE_HAVE_FLASHLIGHT
 #include "flashlight/flashlight_app.h"
+#endif
+#if THISTLE_HAVE_WEATHER
 #include "weather/weather_app.h"
+#endif
+#if THISTLE_HAVE_TERMINAL
 #include "terminal/terminal_app.h"
+#endif
+#if THISTLE_HAVE_VAULT
 #include "vault/vault_app.h"
+#endif
 
 /* Defined in board_simulator.c (shared with SDL sim) */
 extern void sim_board_set_device(const char *device);
@@ -96,25 +124,53 @@ int main(void)
     printf("display_server_register_wm: %d\n", ret);
 
     /* Register built-in apps — same order as simulator/main.c */
+#if THISTLE_HAVE_LAUNCHER
     launcher_app_register();
+#endif
+#if THISTLE_HAVE_SETTINGS
     settings_app_register();
+#endif
+#if THISTLE_HAVE_FILEMGR
     filemgr_app_register();
+#endif
+#if THISTLE_HAVE_READER
     reader_app_register();
+#endif
+#if THISTLE_HAVE_NOTES
     notes_app_register();
+#endif
+#if THISTLE_HAVE_FLASHLIGHT
     flashlight_app_register();
+#endif
+#if THISTLE_HAVE_VAULT
     vault_app_register();
+#endif
+#if THISTLE_HAVE_APPSTORE
     appstore_app_register();
+#endif
+#if THISTLE_HAVE_TERMINAL
     terminal_app_register();
+#endif
+#if THISTLE_HAVE_ASSISTANT
     assistant_app_register();
+#endif
+#if THISTLE_HAVE_WEATHER
     weather_app_register();
+#endif
 
     /* Conditional apps based on device capabilities */
     if (sim_board_has_radio()) {
+#if THISTLE_HAVE_MESSENGER
         messenger_app_register();
+#endif
+#if THISTLE_HAVE_WIFISCANNER
         wifiscanner_app_register();
+#endif
     }
     if (sim_board_has_gps()) {
+#if THISTLE_HAVE_NAVIGATOR
         navigator_app_register();
+#endif
     }
 
     /* Launch launcher */


### PR DESCRIPTION
Fixes the two post-merge release failures exposed by #113.

- filters removed compiled-in C apps from the WASM simulator and guards their registration while Rust ELF migration continues
- validates the WASM build on pull requests without deploying Pages
- keeps pre-matrix catalog entries without architecture metadata from invalidating the signed five-architecture package matrix
- adds regression coverage for both migration paths

Verification:
- WASM CMake configuration succeeds with migrated app sources absent
- 3 WASM migration tests pass
- 3 package matrix tests pass
- 4 catalog tests pass
- 4 package workflow tests pass
- 15 target matrix tests pass