### PR TITLE
Run trusted CI on the repository runner

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -36,6 +36,11 @@ on:
 permissions:
   contents: read
 
+env:
+  CARGO_BUILD_JOBS: 2
+  CMAKE_BUILD_PARALLEL_LEVEL: 2
+  THISTLE_CI_JOBS: 2
+
 jobs:
   build-packages:
     runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
@@ -87,7 +92,7 @@ jobs:
               local build_dir="$package_dir/build-$TARGET_ARCH"
               cmake -S "$package_dir" -B "$build_dir" \
                 -DCMAKE_TOOLCHAIN_FILE="$IDF_PATH/tools/cmake/toolchain-${TARGET_ARCH}.cmake"
-              cmake --build "$build_dir" --parallel
+              cmake --build "$build_dir" --parallel "$THISTLE_CI_JOBS"
 
               local elf="$build_dir/$entry"
               if [ ! -f "$elf" ]; then

--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   build-packages:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     container: espressif/idf:v5.5
     strategy:
       fail-fast: false
@@ -147,7 +147,7 @@ jobs:
 
   publish-catalog:
     needs: build-packages
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   firmware-build:
     name: Build Firmware (${{ matrix.arch }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     container:
       image: espressif/idf:v5.5
     strategy:
@@ -166,7 +166,7 @@ jobs:
 
   rust-tests:
     name: Rust Kernel Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -214,7 +214,7 @@ jobs:
 
   semgrep:
     name: Semgrep SAST
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     container:
       image: semgrep/semgrep
     steps:
@@ -286,7 +286,7 @@ jobs:
 
   trivy:
     name: Trivy Security Scan
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -328,7 +328,7 @@ jobs:
 
   recovery-build:
     name: Build Recovery OS (Rust/esp)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,11 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  CARGO_BUILD_JOBS: 2
+  CMAKE_BUILD_PARALLEL_LEVEL: 2
+  THISTLE_CI_JOBS: 2
+
 jobs:
   firmware-build:
     name: Build Firmware (${{ matrix.arch }})
@@ -78,7 +83,7 @@ jobs:
           . $IDF_PATH/export.sh
           export PATH="$HOME/.cargo/bin:$PATH"
           idf.py set-target "$TARGET_ARCH"
-          idf.py build
+          idf.py -j "$THISTLE_CI_JOBS" build
 
       - name: Check firmware size
         shell: bash
@@ -171,6 +176,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config
 
       - name: Cache Rust toolchain
         uses: actions/cache@v6
@@ -333,6 +343,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libudev-dev pkg-config
 
       - name: Cache Rust ESP toolchain
         uses: actions/cache@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -347,7 +347,7 @@ jobs:
       - name: Install native build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libudev-dev pkg-config
+          sudo apt-get install -y build-essential cmake libudev-dev pkg-config python3-venv
 
       - name: Cache Rust ESP toolchain
         uses: actions/cache@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
           . $IDF_PATH/export.sh
           export PATH="$HOME/.cargo/bin:$PATH"
           idf.py set-target "$TARGET_ARCH"
-          idf.py -j "$THISTLE_CI_JOBS" build
+          idf.py build
 
       - name: Check firmware size
         shell: bash

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,6 +19,11 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  CARGO_BUILD_JOBS: 2
+  CMAKE_BUILD_PARALLEL_LEVEL: 2
+  THISTLE_CI_JOBS: 2
+
 concurrency:
   group: pages
   cancel-in-progress: true
@@ -31,6 +36,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake xz-utils
 
       - name: Cache Rust toolchain
         uses: actions/cache@v6
@@ -87,7 +97,7 @@ jobs:
           cd wasm
           mkdir -p build && cd build
           emcmake cmake ..
-          make -j"$(nproc)"
+          make -j"$THISTLE_CI_JOBS"
 
       - name: Assemble Pages site
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   build:
     name: Build Docs + WASM Simulator
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -126,7 +126,7 @@ jobs:
     name: Deploy to GitHub Pages
     if: github.event_name == 'push'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     environment:
       name: github-pages
     steps:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -78,6 +78,7 @@ jobs:
           if [ ! -f "$HOME/.cargo/bin/cargo" ]; then
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           fi
+          export PATH="$HOME/.cargo/bin:$PATH"
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           rustup target add wasm32-unknown-emscripten
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   publish:
     name: Publish GitHub release
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   board-catalog-validation:
     name: Board Catalog Validation
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -33,7 +33,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests (Host)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -171,7 +171,7 @@ jobs:
 
   simulator-boot:
     name: Simulator Boot Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -221,7 +221,7 @@ jobs:
 
   simulator-integration:
     name: Simulator Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     needs: simulator-boot  # Only run if basic boot passes
     steps:
       - uses: actions/checkout@v6
@@ -269,7 +269,7 @@ jobs:
 
   rust-kernel-tests:
     name: Rust Kernel Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -298,7 +298,7 @@ jobs:
 
   manifest-memory-safety:
     name: Manifest Loader (Valgrind)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","wan0-ci","thistle-os"]') }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: read
 
+env:
+  CARGO_BUILD_JOBS: 2
+  CMAKE_BUILD_PARALLEL_LEVEL: 2
+  THISTLE_CI_JOBS: 2
+
 jobs:
   board-catalog-validation:
     name: Board Catalog Validation
@@ -48,7 +53,7 @@ jobs:
         run: cmake -S simulator -B simulator/build-tests
 
       - name: Build simulator unit tests
-        run: cmake --build simulator/build-tests --target thistle_sim_tests --parallel
+        run: cmake --build simulator/build-tests --target thistle_sim_tests --parallel "$THISTLE_CI_JOBS"
 
       - name: Run simulator unit tests
         run: ./simulator/build-tests/thistle_sim_tests
@@ -210,7 +215,7 @@ jobs:
         working-directory: simulator
         run: |
           mkdir -p build && cd build
-          cmake .. && make -j$(nproc)
+          cmake .. && make -j"$THISTLE_CI_JOBS"
 
       - name: Run boot test
         working-directory: simulator
@@ -261,7 +266,7 @@ jobs:
         working-directory: simulator
         run: |
           mkdir -p build && cd build
-          cmake .. && make -j$(nproc)
+          cmake .. && make -j"$THISTLE_CI_JOBS"
 
       - name: Run integration tests
         working-directory: simulator
@@ -274,6 +279,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config
 
       - name: Cache Rust toolchain and build
         uses: actions/cache@v6
@@ -304,14 +314,14 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Rust and Valgrind
+      - name: Install Rust and native build dependencies
         run: |
           if [ ! -f "$HOME/.cargo/bin/cargo" ]; then
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           fi
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           sudo apt-get update
-          sudo apt-get install -y valgrind
+          sudo apt-get install -y build-essential valgrind
 
       - name: Build manifest parser test binary
         working-directory: components/kernel_rs


### PR DESCRIPTION
## Summary
- route same-repository pull requests, `main` pushes, and manual jobs to the dedicated ThistleOS runner
- keep pull requests from public forks on `ubuntu-latest`
- install native dependencies inside the workflows rather than the shared runner image
- cap build parallelism at two jobs to preserve runner heartbeat on the 8-vCPU/16-GB VM

## Security boundary
The runner is repository-scoped and runs on the dedicated runner VM. Container-job support is isolated to the ThistleOS runner service. Fork pull requests cannot select it.

## Validation
- all workflow jobs use the event-aware runner selector
- workflow YAML parsed successfully
- `git diff --check`
- initial live canary reached the runner and exposed missing `xz` plus unbounded resource starvation; both are addressed in this revision