### PR TITLE
Fix CI and harden T-Watch Ultra profile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -356,7 +356,7 @@ jobs:
             ~/.cargo
             ~/.rustup
             ~/.espup
-          key: rust-esp-recovery-${{ runner.os }}-v3-rust185-espup016
+          key: rust-esp-recovery-${{ runner.os }}-v4-rust185-espup016-s3
           # Don't restore from older prefixes — v1 caches contain corrupt
           # espup 0.17.0 state that reproduces the "part" extension error.
 
@@ -380,7 +380,7 @@ jobs:
           # doesn't try to re-use them.
           find "$HOME/.rustup" "$HOME/.espup" -name '*.part' -delete 2>/dev/null || true
           if [ ! -f "$HOME/export-esp.sh" ]; then
-            espup install
+            espup install --targets esp32s3 --stable-version 1.85.0
           fi
           # ldproxy is the linker wrapper cargo invokes for xtensa-esp32s3-espidf.
           # espup installs the toolchain but not ldproxy; cargo install it explicitly.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libsdl2-dev pkg-config cmake build-essential libcurl4-openssl-dev
+          sudo apt-get install -y libsdl2-dev pkg-config cmake build-essential libcurl4-openssl-dev python3-venv
 
       - name: Configure simulator unit tests
         run: cmake -S simulator -B simulator/build-tests
@@ -95,6 +95,15 @@ jobs:
             -o /tmp/test_board_bus_init
           /tmp/test_board_bus_init
 
+      - name: Test strict board fingerprints
+        run: |
+          cc -std=c11 -Wall -Wextra -Werror \
+            -Icomponents/kernel/include \
+            components/kernel/src/board_fingerprint.c \
+            components/kernel/tests/test_board_fingerprint.c \
+            -o /tmp/test_board_fingerprint
+          /tmp/test_board_fingerprint
+
       - name: Test SX1262 interrupt lifecycle
         run: |
           c++ -std=c++17 -Wall -Wextra -Werror -pthread \
@@ -123,14 +132,16 @@ jobs:
 
       - name: Test secure signing-key generation
         run: |
-          python3 -m pip install -r tools/requirements.txt
-          python3 tools/test_sign.py
+          python3 -m venv /tmp/thistle-test-signing-venv
+          /tmp/thistle-test-signing-venv/bin/pip install -r tools/requirements.txt
+          /tmp/thistle-test-signing-venv/bin/python tools/test_sign.py
 
       - name: Test standalone package publication
         run: |
           python3 tools/test_build_catalog.py
           python3 tools/test_package_workflow.py
           python3 tools/test_target_matrix.py
+          python3 tools/test_validate_board_catalog.py
           python3 tools/test_wasm_migration.py
           python3 tools/test_validate_package_matrix.py
 

--- a/apps/appstore/appstore/appstore_ui.c
+++ b/apps/appstore/appstore/appstore_ui.c
@@ -404,8 +404,7 @@ static esp_err_t load_catalog_local(void)
         else if (strcmp(type_str, "driver") == 0) e->type = CATALOG_TYPE_DRIVER;
         else                                       e->type = CATALOG_TYPE_APP;
 
-        e->is_signed    = (e->sig_url[0] != '\0');
-        e->is_installed = (e->id[0] != '\0') && app_is_installed(e->id);
+        e->is_signed = (e->sig_url[0] != '\0');
 
         free(obj);
 
@@ -552,7 +551,6 @@ static void install_btn_cb(lv_event_t *e)
     esp_err_t ret = appstore_install_entry(entry, NULL, NULL);
     if (ret == ESP_OK) {
         toast_show("Installed!", TOAST_SUCCESS, 3000);
-        entry->is_installed = true;
         /* Go back and refresh the list so the [i] badge appears */
         back_to_catalog_cb(NULL);
         build_catalog_list();
@@ -613,7 +611,6 @@ static void remove_btn_cb(lv_event_t *e)
     snprintf(path, sizeof(path), "%s/%s.app.elf", APPS_DIR, entry->id);
 
     if (remove(path) == 0) {
-        entry->is_installed = false;
         toast_show("App removed", TOAST_SUCCESS, 2000);
         ESP_LOGI(TAG, "Removed: %s", path);
         back_to_catalog_cb(NULL);
@@ -876,7 +873,7 @@ static void build_catalog_list(void)
         char top_line[80];
         snprintf(top_line, sizeof(top_line), "> %s%s%s   %s",
                  e->name,
-                 e->is_installed ? " [i]" : "",
+                 (e->type == CATALOG_TYPE_APP && app_is_installed(e->id)) ? " [i]" : "",
                  (e->type == CATALOG_TYPE_DRIVER) ? " [drv]" : "",
                  e->version);
 
@@ -1038,12 +1035,6 @@ static void refresh_server_cb(lv_event_t *e)
         /* Replace in-memory catalog with the fresh data */
         memcpy(s_store.entries, fetched, sizeof(catalog_entry_t) * (size_t)count);
         s_store.entry_count = count;
-
-        /* Mark installed state */
-        for (int i = 0; i < s_store.entry_count; i++) {
-            catalog_entry_t *en = &s_store.entries[i];
-            en->is_installed = (en->type == CATALOG_TYPE_APP) && app_is_installed(en->id);
-        }
 
         /* Persist as local cache */
         save_catalog_cache();

--- a/components/kernel/CMakeLists.txt
+++ b/components/kernel/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 set(KERNEL_SRCS
     "src/kernel_shims.c" "src/tk_wm_shims.c" "src/sdcard_shim.c"
-    "src/link_deps.c" "src/board_fallback.c" "src/board_builtin_drivers.c"
+    "src/link_deps.c" "src/board_fallback.c" "src/board_fingerprint.c"
+    "src/board_builtin_drivers.c"
 )
 set(KERNEL_REQUIRES
     thistle_hal kernel_rs esp_timer freertos esp_partition fatfs vfs app_update

--- a/components/kernel/include/board_fingerprint.h
+++ b/components/kernel/include/board_fingerprint.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define TWATCH_ULTRA_I2C_CST9217    (1u << 0)
+#define TWATCH_ULTRA_I2C_XL9555     (1u << 1)
+#define TWATCH_ULTRA_I2C_BHI260AP   (1u << 2)
+#define TWATCH_ULTRA_I2C_AXP2101    (1u << 3)
+#define TWATCH_ULTRA_I2C_PCF85063A  (1u << 4)
+#define TWATCH_ULTRA_I2C_DRV2605    (1u << 5)
+
+#define TWATCH_ULTRA_I2C_REQUIRED \
+    (TWATCH_ULTRA_I2C_CST9217 | TWATCH_ULTRA_I2C_XL9555 | \
+     TWATCH_ULTRA_I2C_BHI260AP | TWATCH_ULTRA_I2C_AXP2101 | \
+     TWATCH_ULTRA_I2C_PCF85063A | TWATCH_ULTRA_I2C_DRV2605)
+
+bool board_fingerprint_twatch_ultra_complete(int sda, int scl,
+                                              uint8_t observed_devices);

--- a/components/kernel/src/board_fallback.c
+++ b/components/kernel/src/board_fallback.c
@@ -12,6 +12,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "hal/board.h"
+#include "board_fingerprint.h"
 #include "esp_log.h"
 #include <string.h>
 #include <stdio.h>
@@ -36,6 +37,7 @@ static const i2c_pins_t I2C_PIN_COMBOS[] = {
     { 18,  8 },   /* T-Deck, T-Deck Plus */
     { 18, 17 },   /* T-Display-S3, T3-S3 */
     { 13, 14 },   /* T-Deck Pro */
+    {  3,  2 },   /* T-Watch Ultra */
     { 17, 18 },   /* Heltec V3 */
     {  1,  2 },   /* Cardputer */
     {  4,  5 },   /* RAK3312 */
@@ -71,6 +73,9 @@ typedef struct {
     bool has_cst816;
     bool has_ssd1306;
     bool has_cardkb;
+    bool has_xl9555;
+    bool has_pcf85063a;
+    bool has_drv2605;
     int  sda;
     int  scl;
 } scan_result_t;
@@ -101,12 +106,16 @@ static bool try_pin_combo(const i2c_pins_t *pins, scan_result_t *out)
     out->has_cst816   = i2c_probe(bus, ADDR_CST816);
     out->has_ssd1306  = i2c_probe(bus, ADDR_SSD1306);
     out->has_cardkb   = i2c_probe(bus, ADDR_CARDKB);
+    out->has_xl9555   = i2c_probe(bus, 0x20);
+    out->has_pcf85063a = i2c_probe(bus, 0x51);
+    out->has_drv2605  = i2c_probe(bus, 0x5A);
 
     i2c_del_master_bus(bus);
 
     /* Return true if ANY device responded */
     return out->has_tca8418 || out->has_cst328 || out->has_bhi260ap ||
-           out->has_cst816  || out->has_ssd1306 || out->has_cardkb;
+           out->has_cst816  || out->has_ssd1306 || out->has_cardkb ||
+           out->has_xl9555 || out->has_pcf85063a || out->has_drv2605;
 }
 #endif /* !THISTLE_SIMULATOR */
 
@@ -227,19 +236,6 @@ static const char *JSON_T3_S3 =
 "    ]\n"
 "}\n";
 
-static const char *JSON_RAK3312 =
-"{\n"
-"    \"board\": { \"name\": \"RAK WisBlock RAK3312\", \"arch\": \"esp32s3\", \"board_id\": \"rak3312\", \"version\": \"1.0\" },\n"
-"    \"buses\": {\n"
-"        \"spi\": [],\n"
-"        \"i2c\": [{ \"port\": 0, \"sda\": 4, \"scl\": 5, \"freq_hz\": 400000 }]\n"
-"    },\n"
-"    \"drivers\": [\n"
-"        { \"id\": \"com.thistle.drv.radio-sx1262\", \"hal\": \"radio\", \"entry\": \"radio-sx1262.drv.elf\",\n"
-"          \"config\": { \"spi_bus\": -1, \"cs\": -1, \"dio1\": -1, \"rst\": -1, \"busy\": -1, \"internal\": true } }\n"
-"    ]\n"
-"}\n";
-
 /* ── Write board.json to SPIFFS ───────────────────────────────────────────── */
 
 static esp_err_t write_board_json(const char *json_content)
@@ -344,6 +340,24 @@ esp_err_t board_detect_and_write(void)
                      result.has_tca8418, result.has_cst328, result.has_bhi260ap,
                      result.has_cst816, result.has_ssd1306, result.has_cardkb);
 
+            /* The T-Watch Ultra is accepted only when its complete shared-I2C
+             * tuple responds on the documented pins. ACKs cannot prove the
+             * fitted radio, so this base-board fingerprint is only a prompt to
+             * install a signed profile through Recovery; it is never written
+             * as an unsigned embedded board.json. */
+            uint8_t watch_devices =
+                (result.has_cst328 ? TWATCH_ULTRA_I2C_CST9217 : 0) |
+                (result.has_xl9555 ? TWATCH_ULTRA_I2C_XL9555 : 0) |
+                (result.has_bhi260ap ? TWATCH_ULTRA_I2C_BHI260AP : 0) |
+                (result.has_tca8418 ? TWATCH_ULTRA_I2C_AXP2101 : 0) |
+                (result.has_pcf85063a ? TWATCH_ULTRA_I2C_PCF85063A : 0) |
+                (result.has_drv2605 ? TWATCH_ULTRA_I2C_DRV2605 : 0);
+            if (board_fingerprint_twatch_ultra_complete(
+                    result.sda, result.scl, watch_devices)) {
+                ESP_LOGW(TAG, "T-Watch Ultra component tuple detected; signed profile and explicit radio selection required");
+                return ESP_ERR_NOT_SUPPORTED;
+            }
+
             matched_json = match_fingerprint(&result);
             if (matched_json) {
                 break;
@@ -352,9 +366,8 @@ esp_err_t board_detect_and_write(void)
     }
 
     if (!matched_json) {
-        /* No I2C devices found on any pin combo — headless board */
-        ESP_LOGI(TAG, "No I2C devices found on any pin combo — assuming headless (RAK3312)");
-        matched_json = JSON_RAK3312;
+        ESP_LOGW(TAG, "No unique board fingerprint; refusing unsafe fallback");
+        return ESP_ERR_NOT_FOUND;
     }
 
     /* Write the detected config to SPIFFS */

--- a/components/kernel/src/board_fingerprint.c
+++ b/components/kernel/src/board_fingerprint.c
@@ -1,0 +1,9 @@
+#include "board_fingerprint.h"
+
+bool board_fingerprint_twatch_ultra_complete(int sda, int scl,
+                                              uint8_t observed_devices)
+{
+    return sda == 3 && scl == 2 &&
+           (observed_devices & TWATCH_ULTRA_I2C_REQUIRED) ==
+               TWATCH_ULTRA_I2C_REQUIRED;
+}

--- a/components/kernel/tests/test_board_fingerprint.c
+++ b/components/kernel/tests/test_board_fingerprint.c
@@ -1,0 +1,19 @@
+#include "board_fingerprint.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+int main(void)
+{
+    assert(board_fingerprint_twatch_ultra_complete(
+        3, 2, TWATCH_ULTRA_I2C_REQUIRED));
+    assert(!board_fingerprint_twatch_ultra_complete(
+        3, 2, TWATCH_ULTRA_I2C_REQUIRED & ~TWATCH_ULTRA_I2C_AXP2101));
+    assert(!board_fingerprint_twatch_ultra_complete(
+        13, 14, TWATCH_ULTRA_I2C_REQUIRED));
+    assert(board_fingerprint_twatch_ultra_complete(
+        3, 2, TWATCH_ULTRA_I2C_REQUIRED | (1u << 7)));
+
+    puts("board fingerprint tests passed");
+    return 0;
+}

--- a/components/kernel_rs/src/drv_touch_cst9217.rs
+++ b/components/kernel_rs/src/drv_touch_cst9217.rs
@@ -162,7 +162,7 @@ impl TouchState {
             dev: std::ptr::null_mut(),
             cfg: TouchCst9217Config {
                 i2c_bus: std::ptr::null_mut(),
-                i2c_addr: 0x5A,
+                i2c_addr: 0x1A,
                 pin_int: GPIO_NUM_NC,
                 pin_rst: GPIO_NUM_NC,
                 max_x: 410,
@@ -280,7 +280,7 @@ unsafe extern "C" fn cst9217_init(config: *const c_void) -> i32 {
 
     s.cfg = *(config as *const TouchCst9217Config);
     if s.cfg.i2c_addr == 0 {
-        s.cfg.i2c_addr = 0x5A;
+        s.cfg.i2c_addr = 0x1A;
     }
     if s.cfg.max_x == 0 {
         s.cfg.max_x = 410;
@@ -429,7 +429,7 @@ mod tests {
     fn transform_clamps() {
         let cfg = TouchCst9217Config {
             i2c_bus: std::ptr::null_mut(),
-            i2c_addr: 0x5A,
+            i2c_addr: 0x1A,
             pin_int: -1,
             pin_rst: -1,
             max_x: 410,

--- a/docs/twatch-ultra-ancs-build-plan.md
+++ b/docs/twatch-ultra-ancs-build-plan.md
@@ -1,6 +1,6 @@
 # T-Watch Ultra and Apple ANCS Build Plan
 
-Status: proposed implementation plan
+Status: software profile corrected; hardware verification remains pending
 Target: the owner's physical LilyGo T-Watch Ultra
 Primary milestone: a flashable, recoverable watch build with working display,
 touch, power management, and iPhone notifications through Apple ANCS
@@ -29,8 +29,9 @@ The repository already has a useful foundation:
 - GitHub issue #120 tracks production T-Watch Ultra support, with issues
   #121-#127 covering profile/discovery, power, display/touch, RTC/haptics,
   audio, NFC, and radio/peripheral bring-up.
-- `sdcard_layout/config/boards/twatch-ultra.json` is a bring-up profile, not a
-  production profile.
+- `sdcard_layout/config/boards/twatch-ultra.json` now records the correct
+  component tuple and requires explicit radio selection. It remains a bring-up
+  profile until the signed artifact and physical board are verified together.
 - Rust prototypes exist for CO5300 and CST9217, but they are kernel-internal,
   are not the signed standalone `.drv.elf` files named by the profile, and are
   not hardware-verified.
@@ -40,10 +41,8 @@ The repository already has a useful foundation:
   act as a GATT client/notification consumer.
 - `notification.rs` provides an in-memory notification model, but it is not yet
   wired into boot or the watch UI.
-- The existing T-Watch profile contains known incorrect identities: CST9217 is
-  set to `0x5A` instead of the documented `0x1A`, the RTC is named PCF8563
-  instead of PCF85063A, and audio is named PCM5102A instead of MAX98357A plus
-  T3902.
+- The earlier T-Watch profile's incorrect CST9217, RTC, and audio identities
+  have been removed. Catalog validation now rejects their reintroduction.
 - The current built-in driver fallback only covers the T-Deck Pro display,
   keyboard, and touch path. A board JSON that names nonexistent T-Watch driver
   ELFs will therefore skip the essential watch hardware rather than provide a

--- a/sdcard_layout/config/boards/twatch-ultra.json
+++ b/sdcard_layout/config/boards/twatch-ultra.json
@@ -3,8 +3,46 @@
         "name": "LilyGo T-Watch Ultra",
         "arch": "esp32s3",
         "board_id": "twatch-ultra",
-        "version": "0.1"
+        "version": "0.2"
     },
+    "fingerprint": {
+        "match": "all",
+        "required": [
+            { "bus": "i2c", "bus_index": 0, "address": "0x1A", "component": "cst9217" },
+            { "bus": "i2c", "bus_index": 0, "address": "0x20", "component": "xl9555" },
+            { "bus": "i2c", "bus_index": 0, "address": "0x28", "component": "bhi260ap" },
+            { "bus": "i2c", "bus_index": 0, "address": "0x34", "component": "axp2101" },
+            { "bus": "i2c", "bus_index": 0, "address": "0x51", "component": "pcf85063a" },
+            { "bus": "i2c", "bus_index": 0, "address": "0x5A", "component": "drv2605" }
+        ],
+        "reject_partial": true
+    },
+    "variants": {
+        "radio": {
+            "selection": "explicit",
+            "supported": [
+                "sx1262",
+                "sx1280",
+                "cc1101",
+                "lr1121",
+                "si4432"
+            ]
+        }
+    },
+    "components": [
+        { "id": "co5300", "bus": "qspi", "status": "prototype" },
+        { "id": "cst9217", "bus": "i2c", "address": "0x1A", "status": "prototype" },
+        { "id": "xl9555", "bus": "i2c", "address": "0x20", "status": "driver-required" },
+        { "id": "bhi260ap", "bus": "i2c", "address": "0x28", "status": "prototype" },
+        { "id": "axp2101", "bus": "i2c", "address": "0x34", "status": "driver-required" },
+        { "id": "pcf85063a", "bus": "i2c", "address": "0x51", "status": "driver-required" },
+        { "id": "drv2605", "bus": "i2c", "address": "0x5A", "status": "driver-required" },
+        { "id": "max98357a", "bus": "i2s", "status": "driver-required" },
+        { "id": "t3902", "bus": "pdm", "status": "driver-required" },
+        { "id": "mia-m10q", "bus": "uart", "status": "prototype" },
+        { "id": "st25r3916", "bus": "spi", "status": "driver-required" },
+        { "id": "microsd", "bus": "spi", "status": "prototype" }
+    ],
     "buses": {
         "spi": [
             {
@@ -61,25 +99,13 @@
             "entry": "touch-cst9217.drv.elf",
             "config": {
                 "i2c_bus": 0,
-                "i2c_addr": "0x5A",
+                "i2c_addr": "0x1A",
                 "pin_rst_expander": {
                     "driver": "xl9555",
                     "pin": 10
                 },
                 "max_x": 410,
                 "max_y": 502
-            }
-        },
-        {
-            "id": "com.thistle.drv.radio-sx1262",
-            "hal": "radio",
-            "entry": "radio-sx1262.drv.elf",
-            "config": {
-                "spi_bus": 0,
-                "cs": 36,
-                "dio1": 14,
-                "rst": 47,
-                "busy": 48
             }
         },
         {
@@ -105,26 +131,6 @@
             }
         },
         {
-            "id": "com.thistle.drv.audio-pcm5102a",
-            "hal": "audio",
-            "entry": "audio-pcm5102a.drv.elf",
-            "config": {
-                "i2s_bck": 9,
-                "i2s_ws": 10,
-                "i2s_data": 11
-            }
-        },
-        {
-            "id": "com.thistle.drv.rtc-pcf8563",
-            "hal": "rtc",
-            "entry": "pcf8563.drv.elf",
-            "config": {
-                "i2c_bus": 0,
-                "i2c_addr": "0x51",
-                "pin_int": 1
-            }
-        },
-        {
             "id": "com.thistle.drv.sdcard",
             "hal": "storage",
             "entry": "sdcard.drv.elf",
@@ -141,6 +147,7 @@
     ],
     "notes": {
         "status": "bringup",
-        "variant": "SX1262 radio revision. SX1280/CC1101/LR1121/SI4432 revisions need matching radio drivers."
+        "variant": "Radio selection is mandatory during provisioning; the base profile never guesses a fitted radio.",
+        "hardware_verified": false
     }
 }

--- a/simulator/sim_host_app_api.c
+++ b/simulator/sim_host_app_api.c
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Simulator implementations for host TAP app imports not exported by Rust.
 
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
 #include "sim_vfs.h"
 #include "thistle_app.h"
 

--- a/tools/build_board_catalog.py
+++ b/tools/build_board_catalog.py
@@ -38,6 +38,8 @@ def build_catalog(board_dir: Path, base_url: str) -> dict:
                 "sha256": hashlib.sha256(data).hexdigest(),
                 "size_bytes": len(data),
                 "driver_count": len(config.get("drivers", [])),
+                "fingerprint": config.get("fingerprint", {}),
+                "variants": config.get("variants", {}),
             }
         )
 

--- a/tools/test_validate_board_catalog.py
+++ b/tools/test_validate_board_catalog.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Regression tests for component-accurate board profile validation."""
+
+import copy
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from validate_board_catalog import driver_sources, validate_board
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+class BoardCatalogValidationTests(unittest.TestCase):
+    def setUp(self):
+        self.profile = json.loads(
+            (REPO / "sdcard_layout/config/boards/twatch-ultra.json").read_text()
+        )
+        self.known_ids, self.known_entries = driver_sources(REPO)
+
+    def validate(self, profile: dict) -> list[str]:
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "twatch-ultra.json"
+            path.write_text(json.dumps(profile))
+            return validate_board(path, self.known_ids, self.known_entries)
+
+    def test_twatch_profile_is_component_accurate(self):
+        self.assertEqual(self.validate(self.profile), [])
+
+    def test_partial_fingerprint_is_rejected(self):
+        profile = copy.deepcopy(self.profile)
+        profile["fingerprint"]["required"].pop()
+        errors = self.validate(profile)
+        self.assertTrue(any("complete I2C tuple" in error for error in errors))
+
+    def test_malformed_fingerprint_address_is_reported_not_crashed(self):
+        profile = copy.deepcopy(self.profile)
+        profile["fingerprint"]["required"][0]["address"] = "not-an-address"
+        errors = self.validate(profile)
+        self.assertTrue(any("invalid address" in error for error in errors))
+
+    def test_wrong_touch_address_is_rejected(self):
+        profile = copy.deepcopy(self.profile)
+        touch = next(
+            driver for driver in profile["drivers"]
+            if driver["id"] == "com.thistle.drv.touch-cst9217"
+        )
+        touch["config"]["i2c_addr"] = "0x5A"
+        errors = self.validate(profile)
+        self.assertTrue(any("CST9217 address" in error for error in errors))
+
+    def test_preselected_radio_is_rejected(self):
+        profile = copy.deepcopy(self.profile)
+        profile["drivers"].append({
+            "id": "com.thistle.drv.radio-sx1262",
+            "hal": "radio",
+            "entry": "radio-sx1262.drv.elf",
+            "config": {},
+        })
+        errors = self.validate(profile)
+        self.assertTrue(any("must not preselect" in error for error in errors))
+
+    def test_incorrect_legacy_devices_are_rejected(self):
+        profile = copy.deepcopy(self.profile)
+        profile["drivers"].append({
+            "id": "com.thistle.drv.rtc-pcf8563",
+            "hal": "rtc",
+            "entry": "pcf8563.drv.elf",
+            "config": {},
+        })
+        errors = self.validate(profile)
+        self.assertTrue(any("incorrect audio or RTC" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_validate_package_matrix.py
+++ b/tools/test_validate_package_matrix.py
@@ -8,14 +8,19 @@ from validate_package_matrix import SUPPORTED_ARCHES, validate_entries
 
 def entry(arch: str, package_type: str) -> dict:
     suffix = "app.elf" if package_type == "app" else "drv.elf"
-    return {
+    result = {
         "id": f"com.thistle.{arch}.{package_type}",
         "type": package_type,
         "arch": arch,
-        "url": f"https://example.test/apps/{arch}/{package_type}s/pkg.{suffix}",
-        "sig_url": f"https://example.test/apps/{arch}/{package_type}s/pkg.{suffix}.sig",
         "is_signed": True,
     }
+    if package_type == "app":
+        result["package_url"] = f"https://example.test/apps/{arch}/apps/pkg.tap"
+        result["package_sig_url"] = f"{result['package_url']}.sig"
+    else:
+        result["url"] = f"https://example.test/apps/{arch}/drivers/pkg.{suffix}"
+        result["sig_url"] = f"{result['url']}.sig"
+    return result
 
 
 class PackageMatrixValidationTests(unittest.TestCase):
@@ -51,6 +56,22 @@ class PackageMatrixValidationTests(unittest.TestCase):
         })
 
         self.assertEqual(validate_entries(entries), [])
+
+    def test_app_raw_elf_fields_do_not_satisfy_tap_contract(self):
+        entries = [
+            entry(arch, package_type)
+            for arch in SUPPORTED_ARCHES
+            for package_type in ["app", "driver"]
+        ]
+        app = next(item for item in entries if item["type"] == "app")
+        app["url"] = f"https://example.test/apps/{app['arch']}/apps/pkg.app.elf"
+        app["sig_url"] = f"{app['url']}.sig"
+        del app["package_url"]
+        del app["package_sig_url"]
+
+        errors = validate_entries(entries)
+        self.assertTrue(any("package is not signed" in error for error in errors))
+        self.assertTrue(any("URL is not architecture-qualified" in error for error in errors))
 
 
 if __name__ == "__main__":

--- a/tools/validate_board_catalog.py
+++ b/tools/validate_board_catalog.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 REQUIRED_BOARD_KEYS = {"name", "arch", "board_id", "version"}
 VALID_ARCHES = {"esp32", "esp32s2", "esp32s3", "esp32c3", "esp32c6"}
+VALID_FINGERPRINT_BUSES = {"i2c", "spi", "uart"}
 DRIVER_ENTRY_ALIASES = {
     "lcd-st7789-i80.drv.elf": "lcd-st7789.drv.elf",
     "qmi8658.drv.elf": "accel-qmi8658.drv.elf",
@@ -66,6 +67,66 @@ def validate_board(path: Path, known_ids: set[str], known_entries: set[str]) -> 
             errors.append(f"{path}: {drv_id} entry must end with .drv.elf")
         if "hal" not in drv:
             errors.append(f"{path}: {drv_id} missing hal")
+
+    fingerprint = data.get("fingerprint")
+    if fingerprint is not None:
+        if fingerprint.get("match") != "all":
+            errors.append(f"{path}: fingerprint match must be 'all'")
+        required = fingerprint.get("required")
+        if not isinstance(required, list) or len(required) < 2:
+            errors.append(f"{path}: fingerprint requires at least two components")
+        else:
+            seen: set[tuple[str, int, int]] = set()
+            for idx, component in enumerate(required):
+                bus = component.get("bus")
+                bus_index = component.get("bus_index")
+                address = component.get("address")
+                if bus not in VALID_FINGERPRINT_BUSES:
+                    errors.append(f"{path}: fingerprint.required[{idx}] has invalid bus")
+                    continue
+                if not isinstance(bus_index, int) or bus_index < 0:
+                    errors.append(f"{path}: fingerprint.required[{idx}] has invalid bus_index")
+                    continue
+                try:
+                    numeric_address = int(address, 0) if isinstance(address, str) else int(address)
+                except (TypeError, ValueError):
+                    errors.append(f"{path}: fingerprint.required[{idx}] has invalid address")
+                    continue
+                if bus == "i2c" and not 0 < numeric_address < 0x80:
+                    errors.append(f"{path}: fingerprint.required[{idx}] I2C address is out of range")
+                key = (bus, bus_index, numeric_address)
+                if key in seen:
+                    errors.append(f"{path}: fingerprint contains duplicate component address {key}")
+                seen.add(key)
+        if fingerprint.get("reject_partial") is not True:
+            errors.append(f"{path}: fingerprint must reject partial matches")
+
+    if board.get("board_id") == "twatch-ultra":
+        expected_addresses = {0x1A, 0x20, 0x28, 0x34, 0x51, 0x5A}
+        actual_addresses = set()
+        for item in data.get("fingerprint", {}).get("required", []):
+            if item.get("bus") != "i2c":
+                continue
+            try:
+                address = item.get("address")
+                actual_addresses.add(int(address, 0) if isinstance(address, str) else int(address))
+            except (TypeError, ValueError):
+                pass
+        if actual_addresses != expected_addresses:
+            errors.append(f"{path}: T-Watch Ultra fingerprint must use the complete I2C tuple")
+        forbidden = {"com.thistle.drv.audio-pcm5102a", "com.thistle.drv.rtc-pcf8563"}
+        configured_ids = {driver.get("id") for driver in data.get("drivers", [])}
+        if configured_ids & forbidden:
+            errors.append(f"{path}: T-Watch Ultra declares an incorrect audio or RTC driver")
+        touch = next((driver for driver in data.get("drivers", []) if driver.get("id") == "com.thistle.drv.touch-cst9217"), None)
+        if not touch or touch.get("config", {}).get("i2c_addr") != "0x1A":
+            errors.append(f"{path}: T-Watch Ultra CST9217 address must be 0x1A")
+        radio = data.get("variants", {}).get("radio", {})
+        supported = set(radio.get("supported", []))
+        if radio.get("selection") != "explicit" or not {"sx1262", "sx1280"} <= supported:
+            errors.append(f"{path}: T-Watch Ultra radio variant must require explicit selection")
+        if any(driver.get("hal") == "radio" for driver in data.get("drivers", [])):
+            errors.append(f"{path}: T-Watch Ultra base profile must not preselect a radio driver")
     return errors
 
 

--- a/tools/validate_package_matrix.py
+++ b/tools/validate_package_matrix.py
@@ -28,9 +28,15 @@ def validate_entries(entries: list[dict]) -> list[str]:
             errors.append(f"{package_id}: unsupported architecture {arch!r}")
             continue
         coverage[arch].add(entry_type)
-        if not entry.get("is_signed") or not entry.get("sig_url"):
+        if entry_type == "app":
+            package_url = entry.get("package_url", "")
+            signature_url = entry.get("package_sig_url", "")
+        else:
+            package_url = entry.get("url", "")
+            signature_url = entry.get("sig_url", "")
+        if not entry.get("is_signed") or not signature_url:
             errors.append(f"{package_id} ({arch}): package is not signed")
-        if f"/{arch}/" not in entry.get("url", ""):
+        if f"/{arch}/" not in package_url:
             errors.append(f"{package_id} ({arch}): URL is not architecture-qualified")
 
     for arch, present_types in sorted(coverage.items()):

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -103,6 +103,7 @@ set(SIM_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../simulator")
 set(WASM_SRCS
     main.c
     platform_stubs.c
+    ${THISTLE_DIR}/components/kernel_rs/http_client_shim.c
     # Simulator drivers (SDL2 display/input, board init)
     ${SIM_DIR}/drivers/sim_display.c
     ${SIM_DIR}/drivers/sim_input.c


### PR DESCRIPTION
## Summary
- repair the host, Linux simulator, firmware, Recovery, WASM, and package-matrix CI failures
- correct the T-Watch Ultra component identities and require explicit radio selection
- reject partial/ambiguous watch fingerprints and unsafe headless fallback guesses
- add catalog and host matcher regression coverage

## Local verification
- 1,355 Rust kernel tests pass
- 17 simulator unit tests pass
- all Python tool tests pass
- strict C board fingerprint tests pass
- Rust WASM target builds

Hardware verification remains explicitly pending; this does not close issue #121.